### PR TITLE
Removes use of `long` durations and cluster.growByOne.

### DIFF
--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerSshDriver.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerSshDriver.java
@@ -13,7 +13,7 @@ public class DockerContainerSshDriver extends AbstractSoftwareProcessSshDriver i
 
         // Wait until the Docker Host has started up
         DockerHost dockerHost = getEntity().getConfig(DockerContainer.DOCKER_HOST);
-        Entities.waitForServiceUp(dockerHost, dockerHost.getConfig(DockerHost.START_TIMEOUT), TimeUnit.SECONDS);
+        Entities.waitForServiceUp(dockerHost, dockerHost.getConfig(DockerHost.START_TIMEOUT));
     }
 
     public String getDockerContainerName() { return getEntity().getAttribute(DockerContainer.DOCKER_CONTAINER_NAME); }

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerNodePlacementStrategy.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerNodePlacementStrategy.java
@@ -81,7 +81,7 @@ public class DockerNodePlacementStrategy extends BalancingNodePlacementStrategy 
             // Grow the Docker host cluster; based on max number of Docker containers
             int maxSize = machine.getMaxSize();
             int delta = (remaining / maxSize) + (remaining % maxSize > 0 ? 1 : 0);
-            Collection<Entity> added = machine.getDockerInfrastructure().getDockerHostCluster().grow(delta);
+            Collection<Entity> added = machine.getDockerInfrastructure().getDockerHostCluster().resizeByDelta(delta);
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Added {} Docker hosts: {}", delta, Iterables.toString(Iterables.transform(added,
                         identity())));

--- a/docker/src/main/java/brooklyn/location/docker/DockerHostLocation.java
+++ b/docker/src/main/java/brooklyn/location/docker/DockerHostLocation.java
@@ -101,7 +101,7 @@ public class DockerHostLocation extends AbstractLocation implements MachineLocat
         // increase size of Docker container cluster
         DynamicCluster cluster = dockerHost.getDockerContainerCluster();
         //Optional<Entity> added = cluster.growByOne(machine, flags);
-        Optional<Entity> added = cluster.growByOne(jcloudsLocation, flags);
+        Optional<Entity> added = cluster.addInSingleLocation(jcloudsLocation, flags);
         if (!added.isPresent()) {
             throw new NoMachinesAvailableException(String.format("Failed to create containers. Limit reached at %s", dockerHost.getDockerHostName()));
         }

--- a/docker/src/main/java/brooklyn/location/docker/DockerLocation.java
+++ b/docker/src/main/java/brooklyn/location/docker/DockerLocation.java
@@ -121,7 +121,7 @@ public class DockerLocation extends AbstractLocation implements DockerVirtualLoc
             DockerHost dockerHost = machine.getOwner();
 
             // Now wait until the host has started up
-            Entities.waitForServiceUp(dockerHost, dockerHost.getConfig(DockerHost.START_TIMEOUT), TimeUnit.SECONDS);
+            Entities.waitForServiceUp(dockerHost, dockerHost.getConfig(DockerHost.START_TIMEOUT));
             // Obtain a new Docker container location, save and return it
             DockerHostLocation location = dockerHost.getDynamicLocation();
             DockerContainerLocation container = location.obtain(MutableMap.of("imageId", "e26387043472295e639b3e2be465e6bf5c2026ee5a0e15e63d980ba9a2f45c1a"));


### PR DESCRIPTION
Fixes build for recent API changes in core Brooklyn.
