### PR TITLE
Use Docker official IANA ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Build and run the examples as follows:
 Where `location` can be e.g. `jclouds:softlayer`, or a named location or a fixed IP e.g. `byon:(hosts="1.2.3.4")`. Those
 simple steps will give you a running docker instance on your favourite cloud.
 
-**Important**: Please be sure that the location allows incoming connections on TCP port *4243* (the Docker daemon) and in
+**Important**: Please be sure that the location allows incoming connections on TCP ports *2375-2376* (the Docker daemon) and in
 the range *49000-49900* used by Docker to map container ports onto ports on the hosts public IP address. If you create a
 security group on AWS called _docker_ this will be used automatically by the application.
 


### PR DESCRIPTION
Docker now has official IANA ports and these should be used instead
http://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=docker
