### PR TITLE
Enable or disable Weave SDN in the SimpleDockerCloud

### DIFF
--- a/examples/src/main/java/brooklyn/clocker/example/SimpleDockerCloud.java
+++ b/examples/src/main/java/brooklyn/clocker/example/SimpleDockerCloud.java
@@ -56,7 +56,7 @@ public class SimpleDockerCloud extends AbstractApplication {
     @CatalogConfig(label="Maximum Containers per Host", priority=50)
     public static final ConfigKey<Integer> DOCKER_CONTAINER_CLUSTER_MAX_SIZE = ConfigKeys.newConfigKeyWithDefault(BreadthFirstPlacementStrategy.DOCKER_CONTAINER_CLUSTER_MAX_SIZE, 4);
 
-    @CatalogConfig(label="Weave enabled", priority=50)
+    @CatalogConfig(label="Enable Weave SDN", priority=50)
     public static final ConfigKey<Boolean> WEAVE_ENABLED = ConfigKeys.newConfigKeyWithDefault(WeaveInfrastructure.ENABLED, false);
 
     @Override


### PR DESCRIPTION
When using the SimpleDockerCloud we encountered a NullPointerException. It appeared that a Weave Container had not been created for the Docker Host. The WeaveInfrastructure appeared to be present. I did not spend much looking at why this failed and instead decided to disable Weave. I added some config to allow the SimpleDockerCloud to enable or disable Weave on the DockerInfrastructure it creates. By default I have set to disable Weave, you may wish to enable it by default.

brooklyn.util.exceptions.PropagatedRuntimeException: Error invoking start at DiffusionServerImpl{id=tUPze5At}: java.lang.NullPointerException
at brooklyn.management.internal.EffectorUtils.handleEffectorException(EffectorUtils.java:262)
at brooklyn.entity.effector.EffectorTasks$EffectorBodyTaskFactory$2.handleException(EffectorTasks.java:89)
at brooklyn.util.task.DynamicSequentialTask.handleException(DynamicSequentialTask.java:421)
at brooklyn.util.task.DynamicSequentialTask$DstJob.call(DynamicSequentialTask.java:373)
at brooklyn.util.task.BasicExecutionManager$SubmissionCallable.call(BasicExecutionManager.java:406)
at java.util.concurrent.FutureTask.run(FutureTask.java:262)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
at java.lang.Thread.run(Thread.java:745)
Caused by: brooklyn.util.exceptions.PropagatedRuntimeException: Error invoking start at DiffusionServerImpl{id=tUPze5At}: java.lang.NullPointerException
at brooklyn.management.internal.EffectorUtils.handleEffectorException(EffectorUtils.java:262)
at brooklyn.management.internal.EffectorUtils.invokeMethodEffector(EffectorUtils.java:254)
at brooklyn.entity.basic.MethodEffector.call(MethodEffector.java:149)
at brooklyn.entity.trait.Startable$StartEffectorBody.call(Startable.java:52)
at brooklyn.entity.trait.Startable$StartEffectorBody.call(Startable.java:1)
at brooklyn.entity.effector.EffectorTasks$EffectorBodyTaskFactory$1.call(EffectorTasks.java:81)
at brooklyn.util.task.DynamicSequentialTask$DstJob.call(DynamicSequentialTask.java:323)
... 5 more
Caused by: java.util.concurrent.ExecutionException: brooklyn.util.exceptions.PropagatedRuntimeException: java.lang.NullPointerException
at brooklyn.management.internal.AbstractManagementContext.invokeEffectorMethodSync(AbstractManagementContext.java:282)
at brooklyn.management.internal.EffectorUtils.invokeMethodEffector(EffectorUtils.java:249)
... 10 more
Caused by: brooklyn.util.exceptions.PropagatedRuntimeException: java.lang.NullPointerException
at brooklyn.util.exceptions.Exceptions.propagate(Exceptions.java:91)
at brooklyn.util.task.BasicTask.getUnchecked(BasicTask.java:354)
at brooklyn.util.task.DynamicSequentialTask.drain(DynamicSequentialTask.java:451)
at brooklyn.util.task.DynamicTasks.drain(DynamicTasks.java:315)
at brooklyn.util.task.DynamicTasks.waitForLast(DynamicTasks.java:304)
at brooklyn.entity.software.MachineLifecycleEffectorTasks.start(MachineLifecycleEffectorTasks.java:212)
at brooklyn.entity.basic.SoftwareProcessImpl.doStart(SoftwareProcessImpl.java:473)
at brooklyn.entity.basic.SoftwareProcessImpl.start(SoftwareProcessImpl.java:427)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:606)
at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:90)
at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:233)
at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1047)
at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:877)
at groovy.lang.DelegatingMetaClass.invokeMethod(DelegatingMetaClass.java:149)
at groovy.lang.MetaObjectProtocol$invokeMethod.call(Unknown Source)
at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:42)
at groovy.lang.MetaObjectProtocol$invokeMethod.call(Unknown Source)
at brooklyn.util.GroovyJavaMethods.invokeMethodOnMetaClass(GroovyJavaMethods.groovy:144)
at brooklyn.management.internal.AbstractManagementContext.invokeEffectorMethodLocal(AbstractManagementContext.java:255)
at brooklyn.management.internal.AbstractManagementContext.invokeEffectorMethodSync(AbstractManagementContext.java:278)
... 11 more
Caused by: java.util.concurrent.ExecutionException: java.lang.NullPointerException
at java.util.concurrent.FutureTask.report(FutureTask.java:122)
at java.util.concurrent.FutureTask.get(FutureTask.java:188)
at com.google.common.util.concurrent.ForwardingFuture.get(ForwardingFuture.java:63)
at brooklyn.util.task.BasicTask.get(BasicTask.java:343)
at brooklyn.util.task.BasicTask.getUnchecked(BasicTask.java:352)
... 32 more
Caused by: java.lang.NullPointerException
at brooklyn.location.docker.DockerHostLocation.obtain(DockerHostLocation.java:155)
at brooklyn.location.docker.DockerLocation.obtain(DockerLocation.java:167)
at brooklyn.entity.software.MachineLifecycleEffectorTasks$5$1.call(MachineLifecycleEffectorTasks.java:261)
at brooklyn.entity.software.MachineLifecycleEffectorTasks$5$1.call(MachineLifecycleEffectorTasks.java:1)
at brooklyn.util.task.Tasks.withBlockingDetails(Tasks.java:97)
at brooklyn.entity.software.MachineLifecycleEffectorTasks$5.call(MachineLifecycleEffectorTasks.java:259)
at brooklyn.entity.software.MachineLifecycleEffectorTasks$5.call(MachineLifecycleEffectorTasks.java:1)
... 6 more
