### PR TITLE
Stop and remove the container

### DIFF
--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerImpl.java
@@ -199,6 +199,17 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
         getDockerHost().runDockerCommand("start" + getContainerId());
     }
 
+    /**
+     * Remove the container from the host.
+     * <p>
+     * Should only be called when the container is not running.
+     */
+    private void removeContainer() {
+        final String dockerContainerName = getAttribute(DockerContainer.DOCKER_CONTAINER_NAME);
+        LOG.info("Remove container {}", dockerContainerName);
+        getDockerHost().runDockerCommand("rm " + getContainerId());
+    }
+
     private DockerTemplateOptions getDockerTemplateOptions() {
         Entity entity = getRunningEntity();
         DockerTemplateOptions options = DockerTemplateOptions.NONE;
@@ -414,6 +425,10 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
     @Override
     public void stop() {
         ServiceStateLogic.setExpectedState(this, Lifecycle.STOPPING);
+
+        // Stop and remove the Docker container running on the host
+        shutDown();
+        removeContainer();
 
         super.stop();
 


### PR DESCRIPTION
Clocker does not always stop the containers running. It appears that the application running in the container is stopped but that the container is kept running. When the DockerContainer is stopped the container will be stopped and removed from the host. This fixes #52
