### PR TITLE
Remove the location definition with the location

### DIFF
--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerInfrastructureImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerInfrastructureImpl.java
@@ -258,6 +258,7 @@ public class DockerInfrastructureImpl extends BasicStartableImpl implements Dock
             }
         });
 
+        setAttribute(LOCATION_DEFINITION, definition);
         setAttribute(DYNAMIC_LOCATION, location);
         setAttribute(LOCATION_NAME, location.getId());
 
@@ -274,8 +275,13 @@ public class DockerInfrastructureImpl extends BasicStartableImpl implements Dock
             if (mgr.isManaged(location)) {
                 mgr.unmanage(location);
             }
+            final LocationDefinition definition = getAttribute(LOCATION_DEFINITION);
+            if (definition != null) {
+                getManagementContext().getLocationRegistry().removeDefinedLocation(definition.getId());
+            }
         }
 
+        setAttribute(LOCATION_DEFINITION, null);
         setAttribute(DYNAMIC_LOCATION, null);
         setAttribute(LOCATION_NAME, null);
     }


### PR DESCRIPTION
This sets the location definition attribute when creating the location and uses it to unregister the location definition when deleting the location. This fixes #57.
