### PR TITLE
Generalise SSH dockerfile for different distributions

### DIFF
--- a/docker/src/main/resources/brooklyn/entity/container/docker/SshdDockerfile
+++ b/docker/src/main/resources/brooklyn/entity/container/docker/SshdDockerfile
@@ -22,18 +22,18 @@ FROM ${repository}/${imageName}
 MAINTAINER Cloudsoft "brooklyn@cloudsoftcorp.com"
 
 # setup locale
-RUN type locale-gen ; if [[ $? == 0 ]] ; then en_US.UTF-8 ; fi
+RUN type locale-gen ; if [ "$?" -eq "0" ] ; then locale-gen en_US.UTF-8 ; fi
 
 # setup root account
 RUN echo 'root:${entity.password}' | chpasswd
 
 # install sshd
 RUN type apt-get ; \
-  if [[ $? == 0 ]] ; then \
+  if [ "$?" -eq "0" ] ; then \
     apt-get install -y openssh-server ; \
   else \
     yum -y install openssh-server ; \
-  fi \
+  fi ; \
   mkdir /var/run/sshd ; \
   chmod 600 /var/run/sshd ; \
   /usr/sbin/sshd ;


### PR DESCRIPTION
A second dockerfile is used to ensure that the provided dockerfile supports and starts SSH. It assumes that the base dockerfile provides local-gen and apt-get. I have modified the docker file to use "type" to detect the presence of commands so that it has better support for different distributions.
