### PR TITLE
Fixes to get Clocker running as an OSGi bundle.

### DIFF
--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerInfrastructureImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerInfrastructureImpl.java
@@ -52,7 +52,9 @@ import brooklyn.entity.proxying.EntitySpec;
 import brooklyn.entity.trait.Startable;
 import brooklyn.location.Location;
 import brooklyn.location.LocationDefinition;
+import brooklyn.location.LocationRegistry;
 import brooklyn.location.basic.BasicLocationDefinition;
+import brooklyn.location.basic.BasicLocationRegistry;
 import brooklyn.location.docker.DockerLocation;
 import brooklyn.location.docker.DockerResolver;
 import brooklyn.management.LocationManager;
@@ -80,6 +82,7 @@ public class DockerInfrastructureImpl extends BasicStartableImpl implements Dock
     @Override
     public void init() {
         LOG.info("Starting Docker infrastructure id {}", getId());
+        registerLocationResolver();
         super.init();
 
         setAttribute(DOCKER_HOST_COUNTER, new AtomicInteger(0));
@@ -186,6 +189,16 @@ public class DockerInfrastructureImpl extends BasicStartableImpl implements Dock
         }
 
         setAttribute(Attributes.MAIN_URI, URI.create("/clocker"));
+    }
+
+    private void registerLocationResolver() {
+        // Doesn't matter if the resolver is already registered through ServiceLoader.
+        // It just overwrite the existing registration (if any).
+        // TODO Register separate resolvers for each infrastructure instance, unregister on unmanage.
+        LocationRegistry registry = getManagementContext().getLocationRegistry();
+        DockerResolver dockerResolver = new DockerResolver();
+        ((BasicLocationRegistry)registry).registerResolver(dockerResolver);
+        if (LOG.isDebugEnabled()) LOG.debug("Explicitly registered docker resolver: "+dockerResolver);
     }
 
     @Override

--- a/docker/src/main/java/brooklyn/location/docker/DockerHostLocation.java
+++ b/docker/src/main/java/brooklyn/location/docker/DockerHostLocation.java
@@ -59,7 +59,7 @@ import brooklyn.location.basic.LocationConfigKeys;
 import brooklyn.location.basic.SshMachineLocation;
 import brooklyn.location.dynamic.DynamicLocation;
 import brooklyn.location.jclouds.JcloudsLocation;
-import brooklyn.networking.subnet.PortForwarder;
+import brooklyn.networking.common.subnet.PortForwarder;
 import brooklyn.networking.subnet.SubnetTier;
 import brooklyn.util.collections.MutableMap;
 import brooklyn.util.exceptions.Exceptions;


### PR DESCRIPTION
Additionally needed changes:
  * https://github.com/brooklyncentral/advanced-networking/pull/23
  * https://github.com/apache/incubator-brooklyn/pull/446
  * change Brooklyn's jclouds docker dependency to the one used in clocker (1.8.2-alpha-cloudsoft.6 atm)