### PR TITLE
Fix DockerHostSshDriver isRunning

### DIFF
--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerHostSshDriver.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerHostSshDriver.java
@@ -177,6 +177,8 @@ public class DockerHostSshDriver extends AbstractSoftwareProcessSshDriver implem
                 .body.append(alternatives(
                         ifExecutableElse1("boot2docker", "boot2docker status"),
                         ifExecutableElse1("service", sudo("service docker status"))))
+                // otherwise Brooklyn appends 'check-running' and the method always returns true.
+                .noExtraOutput()
                 .gatherOutput();
         helper.execute();
         return helper.getResultStdout().contains("running");
@@ -317,7 +319,10 @@ public class DockerHostSshDriver extends AbstractSoftwareProcessSshDriver implem
 
     @Override
     public void customize() {
-        if (isRunning()) stop();
+        if (isRunning()) {
+            log.info("Stopping running Docker instance at {} before customising", getMachine());
+            stop();
+        }
 
         Networking.checkPortsValid(getPortMap());
 


### PR DESCRIPTION
Without `noExtraOutput` the `stdout` of the command when Docker is not running is like this:
```
/usr/sbin/service
docker stop/waiting
Executed /tmp/brooklyn-20150127-171334283-kshT-check-running_DockerHostImpl_i.sh, result 0
```
Which always contains 'running'!