### PR TITLE
Run entities from named images

### DIFF
--- a/docker/src/main/java/brooklyn/entity/container/DockerAttributes.java
+++ b/docker/src/main/java/brooklyn/entity/container/DockerAttributes.java
@@ -42,42 +42,65 @@ public class DockerAttributes {
      * Configuration.
      */
 
-    public static final ConfigKey<String> DOCKERFILE_URL = ConfigKeys.newStringConfigKey("docker.dockerfile.url", "URL of a Dockerfile to use");
-    public static final ConfigKey<String> DOCKERFILE_NAME = ConfigKeys.newStringConfigKey("docker.dockerfile.name", "Name for the image created by the Dockerfile being used");
+    public static final ConfigKey<String> DOCKERFILE_URL = ConfigKeys.newStringConfigKey(
+            "docker.dockerfile.url", "URL of a Dockerfile to use");
 
-    public static final AttributeSensorAndConfigKey<String, String> DOCKER_IMAGE_ID = ConfigKeys.newStringSensorAndConfigKey("docker.imageId", "The ID of a Docker image to use for a container");
+    public static final ConfigKey<String> DOCKERFILE_NAME = ConfigKeys.newStringConfigKey(
+            "docker.dockerfile.name", "Name for the image created by the Dockerfile being used");
 
-    public static final AttributeSensorAndConfigKey<String, String> DOCKER_IMAGE_NAME = ConfigKeys.newStringSensorAndConfigKey("docker.imageName", "The name of the Docker image use used by a container");
+    public static final AttributeSensorAndConfigKey<String, String> DOCKER_IMAGE_ID = ConfigKeys.newStringSensorAndConfigKey(
+            "docker.imageId", "The ID of a Docker image to use for a container");
 
-    public static final AttributeSensorAndConfigKey<String, String> DOCKER_HARDWARE_ID = ConfigKeys.newSensorAndConfigKey(String.class, "docker.hardwareId", "The ID of a Docker hardware type to use for a container", "small");
+    public static final AttributeSensorAndConfigKey<String, String> DOCKER_IMAGE_NAME = ConfigKeys.newStringSensorAndConfigKey(
+            "docker.imageName", "The name of the Docker image use used by a container");
 
-    public static final ConfigKey<String> DOCKER_PASSWORD = ConfigKeys.newConfigKeyWithPrefix("docker.", SshTool.PROP_PASSWORD);
+    public static final AttributeSensorAndConfigKey<String, String> DOCKER_HARDWARE_ID = ConfigKeys.newStringSensorAndConfigKey(
+            "docker.hardwareId", "The ID of a Docker hardware type to use for a container", "small");
 
-    public static final ConfigKey<Boolean> DOCKER_USE_HOST_DNS_NAME = ConfigKeys.newBooleanConfigKey("docker.useHostDnsName", "Container uses same DNS hostname as Docker host", Boolean.TRUE);
-    public static final ConfigKey<Integer> DOCKER_CPU_SHARES = ConfigKeys.newIntegerConfigKey("docker.cpuShares", "Container CPU shares configuration");
-    public static final ConfigKey<Integer> DOCKER_MEMORY = ConfigKeys.newIntegerConfigKey("docker.memory", "Container memory configuration");
+    public static final ConfigKey<String> DOCKER_PASSWORD = ConfigKeys.newConfigKeyWithPrefix(
+            "docker.", SshTool.PROP_PASSWORD);
 
-    public static final ConfigKey<Boolean> MANAGED = ConfigKeys.newBooleanConfigKey("docker.container.managed", "Set to false if the container is not managed by Brooklyn and Clocker", Boolean.TRUE);
+    public static final ConfigKey<Boolean> DOCKER_USE_HOST_DNS_NAME = ConfigKeys.newBooleanConfigKey(
+            "docker.useHostDnsName", "Container uses same DNS hostname as Docker host", Boolean.TRUE);
+
+    public static final ConfigKey<Integer> DOCKER_CPU_SHARES = ConfigKeys.newIntegerConfigKey(
+            "docker.cpuShares", "Container CPU shares configuration");
+
+    public static final ConfigKey<Integer> DOCKER_MEMORY = ConfigKeys.newIntegerConfigKey(
+            "docker.memory", "Container memory configuration");
+
+    public static final ConfigKey<Boolean> MANAGED = ConfigKeys.newBooleanConfigKey(
+            "docker.container.managed", "Set to false if the container is not managed by Brooklyn and Clocker", Boolean.TRUE);
 
     public static final AttributeSensorAndConfigKey<Map<String, String>, Map<String, String>> DOCKER_HOST_VOLUME_MAPPING = ConfigKeys.newSensorAndConfigKey(
-            new TypeToken<Map<String, String>>() { }, "docker.host.volumes", "Host volume mapping configuration");
+            new TypeToken<Map<String, String>>() { },
+            "docker.host.volumes", "Host volume mapping configuration");
+
     public static final ConfigKey<List<String>> DOCKER_CONTAINER_VOLUME_EXPORT = ConfigKeys.newConfigKey(
-            new TypeToken<List<String>>() { }, "docker.container.volumes", "Container volume export configuration");
+            new TypeToken<List<String>>() { },
+            "docker.container.volumes", "Container volume export configuration");
 
     public static final ConfigKey<List<DockerAwarePlacementStrategy>> PLACEMENT_STRATEGIES = ConfigKeys.newConfigKey(
             new TypeToken<List<DockerAwarePlacementStrategy>>() { },
             "docker.container.strategies", "Placement strategy list for Docker containers");
 
-    public static final ConfigKey<Boolean> WEAVE_ENABLED = ConfigKeys.newBooleanConfigKey("weave.enabled",  "Enable Weave SDN", Boolean.TRUE);
+    public static final ConfigKey<Boolean> WEAVE_ENABLED = ConfigKeys.newBooleanConfigKey(
+            "weave.enabled",  "Enable Weave SDN", Boolean.TRUE);
 
     /*
      * Counter attributes.
      */
+    public static final AttributeSensor<Integer> DOCKER_HOST_COUNT = Sensors.newIntegerSensor(
+            "docker.hosts.total", "Number of Docker hosts");
 
-    public static final AttributeSensor<Integer> DOCKER_HOST_COUNT = Sensors.newIntegerSensor("docker.hosts.total", "Number of Docker hosts");
-    public static final AttributeSensor<Integer> DOCKER_CONTAINER_COUNT = Sensors.newIntegerSensor("docker.containers.total", "Number of Docker containers");
-    public static final AttributeSensor<Integer> DOCKER_IDLE_HOST_COUNT = Sensors.newIntegerSensor("docker.hosts.idle", "Number of idle Docker hosts");
-    public static final AttributeSensor<Integer> DOCKER_IDLE_CONTAINER_COUNT = Sensors.newIntegerSensor("docker.containers.idle", "Number of idle Docker containers");
+    public static final AttributeSensor<Integer> DOCKER_CONTAINER_COUNT = Sensors.newIntegerSensor(
+            "docker.containers.total", "Number of Docker containers");
+
+    public static final AttributeSensor<Integer> DOCKER_IDLE_HOST_COUNT = Sensors.newIntegerSensor(
+            "docker.hosts.idle", "Number of idle Docker hosts");
+
+    public static final AttributeSensor<Integer> DOCKER_IDLE_CONTAINER_COUNT = Sensors.newIntegerSensor(
+            "docker.containers.idle", "Number of idle Docker containers");
 
     private static AtomicBoolean initialized = new AtomicBoolean(false);
 

--- a/docker/src/main/java/brooklyn/entity/container/DockerAttributes.java
+++ b/docker/src/main/java/brooklyn/entity/container/DockerAttributes.java
@@ -49,16 +49,19 @@ public class DockerAttributes {
             "docker.dockerfile.name", "Name for the image created by the Dockerfile being used");
 
     public static final AttributeSensorAndConfigKey<String, String> DOCKER_IMAGE_ID = ConfigKeys.newStringSensorAndConfigKey(
-            "docker.imageId", "The ID of a Docker image to use for a container");
+            "docker.image.id", "The ID of a Docker image to use for a container");
 
     public static final AttributeSensorAndConfigKey<String, String> DOCKER_IMAGE_NAME = ConfigKeys.newStringSensorAndConfigKey(
-            "docker.imageName", "The name of the Docker image use used by a container");
+            "docker.image.name", "The name of the Docker image used by a container");
+
+    public static final AttributeSensorAndConfigKey<String, String> DOCKER_IMAGE_TAG = ConfigKeys.newStringSensorAndConfigKey(
+            "docker.image.tag", "The tag of the image to use", "latest");
 
     public static final AttributeSensorAndConfigKey<String, String> DOCKER_HARDWARE_ID = ConfigKeys.newStringSensorAndConfigKey(
             "docker.hardwareId", "The ID of a Docker hardware type to use for a container", "small");
 
     public static final ConfigKey<String> DOCKER_PASSWORD = ConfigKeys.newConfigKeyWithPrefix(
-            "docker.", SshTool.PROP_PASSWORD);
+            "docker.password", SshTool.PROP_PASSWORD);
 
     public static final ConfigKey<Boolean> DOCKER_USE_HOST_DNS_NAME = ConfigKeys.newBooleanConfigKey(
             "docker.useHostDnsName", "Container uses same DNS hostname as Docker host", Boolean.TRUE);

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerContainer.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerContainer.java
@@ -66,6 +66,12 @@ public interface DockerContainer extends BasicStartable, HasShortName, LocationO
     @SetFromFlag("imageId")
     ConfigKey<String> DOCKER_IMAGE_ID = DockerAttributes.DOCKER_IMAGE_ID.getConfigKey();
 
+    @SetFromFlag("imageName")
+    ConfigKey<String> DOCKER_IMAGE_NAME = DockerAttributes.DOCKER_IMAGE_NAME.getConfigKey();
+
+    @SetFromFlag("imageTag")
+    ConfigKey<String> DOCKER_IMAGE_TAG = DockerAttributes.DOCKER_IMAGE_TAG.getConfigKey();
+
     @SetFromFlag("hardwareId")
     ConfigKey<String> DOCKER_HARDWARE_ID = DockerAttributes.DOCKER_HARDWARE_ID.getConfigKey();
 
@@ -87,15 +93,16 @@ public interface DockerContainer extends BasicStartable, HasShortName, LocationO
             "docker.container.environment", "Environment variables for the Docker container");
 
     @SetFromFlag("entity")
-    AttributeSensorAndConfigKey<Entity, Entity> ENTITY = ConfigKeys.newSensorAndConfigKey(Entity.class, "docker.container.entity", "The entity running in this Docker container");
+    AttributeSensorAndConfigKey<Entity, Entity> ENTITY = ConfigKeys.newSensorAndConfigKey(Entity.class,
+            "docker.container.entity", "The entity running in this Docker container");
 
     ConfigKey<String> DOCKER_CONTAINER_NAME_FORMAT = ConfigKeys.newStringConfigKey("docker.container.nameFormat",
             "Format for generating Docker container names", DockerUtils.DEFAULT_DOCKER_CONTAINER_NAME_FORMAT);
 
     AttributeSensor<String> DOCKER_CONTAINER_NAME = Sensors.newStringSensor("docker.container.name", "The name of the Docker container");
 
-    AttributeSensor<String> IMAGE_ID = Sensors.newStringSensor("docker.container.imageId", "The Docker container image ID");
-    AttributeSensor<String> IMAGE_NAME = Sensors.newStringSensor("docker.container.imageName", "The Docker container image name");
+    AttributeSensor<String> IMAGE_ID = Sensors.newStringSensor("docker.container.image.id", "The Docker container image ID");
+    AttributeSensor<String> IMAGE_NAME = Sensors.newStringSensor("docker.container.image.name", "The Docker container image name");
     AttributeSensor<String> HARDWARE_ID = Sensors.newStringSensor("docker.container.hardwareId", "The Docker container hardware ID");
     AttributeSensor<String> CONTAINER_ID = Sensors.newStringSensor("docker.container.id", "The Docker container ID");
 

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerImpl.java
@@ -474,6 +474,13 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
 
     @Override
     public void stop() {
+        Lifecycle state = getAttribute(SERVICE_STATE_ACTUAL);
+        if (Lifecycle.STOPPING.equals(state) || Lifecycle.STOPPED.equals(state)) {
+            LOG.debug("Ignoring request to stop {} when it is already {}", this, state);
+            LOG.trace("Duplicate stop came from: \n" + Joiner.on("\n").join(Thread.getAllStackTraces().get(Thread.currentThread())));
+            return;
+        }
+        LOG.info("Stopping {} when its state is {}", this, getAttribute(SERVICE_STATE_ACTUAL));
         ServiceStateLogic.setExpectedState(this, Lifecycle.STOPPING);
 
         disconnectSensors();

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerImpl.java
@@ -105,6 +105,7 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
     }
 
     protected void connectSensors() {
+        // is this swappable for a feed that runs one command rather than three?
         status = FunctionFeed.builder()
                 .entity(this)
                 .period(Duration.seconds(15))
@@ -241,8 +242,8 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
         if (cpuShares == null) cpuShares = getConfig(DOCKER_CPU_SHARES);
         if (cpuShares != null) {
             // TODO set based on number of cores available in host divided by cores requested in flags
-            Integer hostCores = (int) getDockerHost().getDynamicLocation().getMachine().getMachineDetails().getHardwareDetails().getCpuCount();
-            Integer minCores = (Integer) entity.getConfig(JcloudsLocationConfig.MIN_CORES);
+            Integer hostCores = getDockerHost().getDynamicLocation().getMachine().getMachineDetails().getHardwareDetails().getCpuCount();
+            Integer minCores = entity.getConfig(JcloudsLocationConfig.MIN_CORES);
             Map flags = entity.getConfig(SoftwareProcess.PROVISIONING_PROPERTIES);
             if (minCores == null && flags != null) {
                 minCores = (Integer) flags.get(JcloudsLocationConfig.MIN_CORES.getName());
@@ -257,7 +258,7 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
                 }
             }
             if (minCores != null) {
-                double ratio = (double) minCores / (double) hostCores;
+                double ratio = (double) minCores / (double) (hostCores != null ? hostCores : 1);
                 LOG.info("Cores: host {}, min {}, ratio {}", new Object[] { hostCores, minCores, ratio });
             }
         }

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerImpl.java
@@ -189,7 +189,7 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
     @Override
     public void shutDown() {
         String dockerContainerName = getAttribute(DockerContainer.DOCKER_CONTAINER_NAME);
-        LOG.info("Shut-Down {}", dockerContainerName);
+        LOG.info("Stopping {}", dockerContainerName);
         getDockerHost().runDockerCommand("kill " + getContainerId());
     }
 
@@ -203,7 +203,7 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
     @Override
     public void resume() {
         String dockerContainerName = getAttribute(DockerContainer.DOCKER_CONTAINER_NAME);
-        LOG.info("Resume {}", dockerContainerName);
+        LOG.info("Resuming {}", dockerContainerName);
         getDockerHost().runDockerCommand("start" + getContainerId());
     }
 
@@ -214,7 +214,7 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
      */
     private void removeContainer() {
         final String dockerContainerName = getAttribute(DockerContainer.DOCKER_CONTAINER_NAME);
-        LOG.info("Remove container {}", dockerContainerName);
+        LOG.info("Removing {}", dockerContainerName);
         getDockerHost().runDockerCommand("rm " + getContainerId());
     }
 

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerHost.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerHost.java
@@ -49,6 +49,7 @@ import brooklyn.util.collections.MutableMap;
 import brooklyn.util.flags.SetFromFlag;
 import brooklyn.util.time.Duration;
 
+import com.google.common.base.Optional;
 import com.google.common.reflect.TypeToken;
 
 /**
@@ -152,6 +153,17 @@ public interface DockerHost extends MachineEntity, Resizable, HasShortName, Loca
     List<Entity> getDockerContainerList();
 
     DockerInfrastructure getInfrastructure();
+
+
+    /**
+     * As {@link #getImageNamed(String, String)} and looking for the latest image.
+     */
+    Optional<String> getImageNamed(String name);
+
+    /**
+     * @return an Optional containing the ID of the named and tagged image.
+     */
+    Optional<String> getImageNamed(String name, String tag);
 
     MethodEffector<String> CREATE_SSHABLE_IMAGE = new MethodEffector<String>(DockerHost.class, "createSshableImage");
     MethodEffector<String> RUN_DOCKER_COMMAND = new MethodEffector<String>(DockerHost.class, "runDockerCommand");

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerHost.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerHost.java
@@ -180,7 +180,19 @@ public interface DockerHost extends MachineEntity, Resizable, HasShortName, Loca
     @Effector(description="Create an SSHable image and returns the image ID")
     String createSshableImage(
             @EffectorParam(name="dockerFile", description="URL of Dockerfile to copy") String dockerFile,
-            @EffectorParam(name="folder", description="Repository name") String name);
+            @EffectorParam(name="name", description="Repository name") String name);
+
+    /**
+     * Create an SSHable image based on the image with the given name.
+     *
+     * @param baseImage The parent image to base the new image on, e.g. "tomcat" or "redis"
+     * @param tag The tag of the parent image, e.g. "latest"
+     * @return the new image's ID
+     */
+    @Effector(description="Create an SSHable image based on the named image and return its ID")
+    String layerSshableImageOn(
+            @EffectorParam(name="baseImage", description="The image's name") String baseImage,
+            @EffectorParam(name="tag", description="The image's tag, e.g. latest") String tag);
 
     /**
      * Execute a Docker command and return the output.

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerHost.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerHost.java
@@ -55,7 +55,7 @@ import com.google.common.reflect.TypeToken;
  * A single machine running Docker.
  * <p>
  * This entity controls the {@link DockerHostLocation} location, and creates
- * and wraps a {@link JcloudsLocatiopn} representing the API for the Docker
+ * and wraps a {@link JcloudsLocation} representing the API for the Docker
  * service on this machine.
  */
 @ImplementedBy(DockerHostImpl.class)

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerHostDriver.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerHostDriver.java
@@ -40,6 +40,14 @@ public interface DockerHostDriver extends SoftwareProcessDriver {
      */
     String buildImage(String dockerFile, String name);
 
+    /**
+     * Build an SSHable Docker image that is based from an image with the given name.
+     *
+     * @param name e.g. tomcat:8.0
+     * @return the new image's ID
+     */
+    String layerSshableImageOn(String name, String tag);
+
     String deployArchive(String url);
 
     void configureSecurityGroups();

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerHostImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerHostImpl.java
@@ -229,8 +229,8 @@ public class DockerHostImpl extends MachineEntityImpl implements DockerHost {
                     flags.put("securityGroups", securityGroup);
                 }
             } else {
-                flags.put(JcloudsLocationConfig.JCLOUDS_LOCATION_CUSTOMIZER.getName(),
-                        JcloudsLocationSecurityGroupCustomizer.getInstance(getApplicationId()));
+                flags.put(JcloudsLocationConfig.JCLOUDS_LOCATION_CUSTOMIZERS.getName(),
+                        ImmutableList.of(JcloudsLocationSecurityGroupCustomizer.getInstance(getApplicationId())));
             }
         }
         return flags;

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerHostImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerHostImpl.java
@@ -354,6 +354,17 @@ public class DockerHostImpl extends MachineEntityImpl implements DockerHost {
     @Override
     public SubnetTier getSubnetTier() { return getAttribute(DOCKER_HOST_SUBNET_TIER); }
 
+    @Override
+    public Optional<String> getImageNamed(String repository) {
+        return getImageNamed(repository, "latest");
+    }
+
+    @Override
+    public Optional<String> getImageNamed(String repository, String tag) {
+        String imageList = runDockerCommand("images --no-trunc " + repository);
+        return Optional.fromNullable(Strings.getFirstWordAfter(imageList, tag));
+    }
+
     /**
      * Create a new {@link DockerHostLocation} wrapping the machine we are starting in.
      */

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerHostImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerHostImpl.java
@@ -305,7 +305,14 @@ public class DockerHostImpl extends MachineEntityImpl implements DockerHost {
     @Override
     public String createSshableImage(String dockerFile, String name) {
         String imageId = getDriver().buildImage(dockerFile, name);
-        if (LOG.isDebugEnabled()) LOG.debug("Successfully created image {} ({}/{})", new Object[] { imageId, getRepository(), name });
+        LOG.debug("Successfully created image {} ({}/{})", new Object[] { imageId, getRepository(), name });
+        return imageId;
+    }
+
+    @Override
+    public String layerSshableImageOn(String baseImage, String tag) {
+        String imageId = getDriver().layerSshableImageOn(baseImage, tag);
+        LOG.debug("Successfully created SSHable image {} from {}", imageId, baseImage);
         return imageId;
     }
 
@@ -355,13 +362,13 @@ public class DockerHostImpl extends MachineEntityImpl implements DockerHost {
     public SubnetTier getSubnetTier() { return getAttribute(DOCKER_HOST_SUBNET_TIER); }
 
     @Override
-    public Optional<String> getImageNamed(String repository) {
-        return getImageNamed(repository, "latest");
+    public Optional<String> getImageNamed(String name) {
+        return getImageNamed(name, "latest");
     }
 
     @Override
-    public Optional<String> getImageNamed(String repository, String tag) {
-        String imageList = runDockerCommand("images --no-trunc " + repository);
+    public Optional<String> getImageNamed(String name, String tag) {
+        String imageList = runDockerCommand("images --no-trunc " + name);
         return Optional.fromNullable(Strings.getFirstWordAfter(imageList, tag));
     }
 

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerHostSshDriver.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerHostSshDriver.java
@@ -16,6 +16,7 @@
 package brooklyn.entity.container.docker;
 
 import static brooklyn.util.ssh.BashCommands.*;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
 
 import java.util.Collection;
@@ -133,6 +134,19 @@ public class DockerHostSshDriver extends AbstractSoftwareProcessSshDriver implem
                 false, getExtraTemplateSubstitutions(name));
         String sshdImageId = buildDockerfile("Sshd" + DockerUtils.DOCKERFILE, name);
         log.info("Created SSHable Dockerfile image with ID {}", sshdImageId);
+
+        return sshdImageId;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String layerSshableImageOn(String name, String tag) {
+        checkNotNull(name, "name");
+        checkNotNull(tag, "tag");
+        copyTemplate(DockerUtils.SSHD_DOCKERFILE, Os.mergePaths(name, "Sshd" + DockerUtils.DOCKERFILE),
+                true, ImmutableMap.<String, Object>of("fullyQualifiedImageName", Os.mergePaths(name) + ":" + tag));
+        String sshdImageId = buildDockerfile("Sshd" + DockerUtils.DOCKERFILE, name);
+        log.info("Created SSH-based image from {} with ID {}", name, sshdImageId);
 
         return sshdImageId;
     }

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerHostSshDriver.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerHostSshDriver.java
@@ -206,15 +206,16 @@ public class DockerHostSshDriver extends AbstractSoftwareProcessSshDriver implem
         String arch = osDetails.getArch();
         if (!osDetails.is64bit()) { throw new IllegalStateException("Docker supports only 64bit OS"); }
         if (osDetails.isLinux()) {
-            if (osDetails.getName().equalsIgnoreCase("ubuntu") && osVersion.equals("12.04")) {
-                List<String> commands = ImmutableList.<String> builder().add(installPackage("linux-image-generic-lts-raring"))
+            if ("ubuntu".equalsIgnoreCase(osDetails.getName()) && "12.04".equalsIgnoreCase(osVersion)) {
+                List<String> commands = ImmutableList.<String> builder()
+                        .add(installPackage("linux-image-generic-lts-raring"))
                         .add(installPackage("linux-headers-generic-lts-raring"))
                         .add(sudo("reboot"))
                         .build();
                 executeKernelInstallation(commands);
             }
-            if (osDetails.getName().equalsIgnoreCase("centos")) {
-                List<String> commands = ImmutableList.<String> builder()
+            if ("centos".equalsIgnoreCase(osDetails.getName())) {
+                List<String> commands = ImmutableList.<String>builder()
                         .add(sudo("yum -y --nogpgcheck upgrade kernel"))
                         .add(sudo("reboot"))
                         .build();
@@ -267,9 +268,9 @@ public class DockerHostSshDriver extends AbstractSoftwareProcessSshDriver implem
 
         List<String> commands = Lists.newArrayList();
         commands.add(INSTALL_CURL);
-        if (osDetails.getName().equalsIgnoreCase("ubuntu")) {
+        if ("ubuntu".equalsIgnoreCase(osDetails.getName())) {
             commands.add(installDockerOnUbuntu());
-        } else if (osDetails.getName().equalsIgnoreCase("centos")) { // should work for RHEL also?
+        } else if ("centos".equalsIgnoreCase(osDetails.getName())) { // should work for RHEL also?
             commands.add(ifExecutableElse1("yum", useYum(osVersion, arch, getEpelRelease())));
             commands.add(installPackage(ImmutableMap.of("yum", "docker-io"), null));
             commands.add(sudo(format("curl https://get.docker.com/builds/Linux/x86_64/docker-%s -o /usr/bin/docker", getVersion())));

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerHostSshDriver.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerHostSshDriver.java
@@ -42,6 +42,7 @@ import brooklyn.management.Task;
 import brooklyn.util.collections.MutableList;
 import brooklyn.util.collections.MutableMap;
 import brooklyn.util.file.ArchiveUtils;
+import brooklyn.util.file.ArchiveUtils.ArchiveType;
 import brooklyn.util.net.Cidr;
 import brooklyn.util.net.Networking;
 import brooklyn.util.net.Urls;
@@ -72,8 +73,7 @@ public class DockerHostSshDriver extends AbstractSoftwareProcessSshDriver implem
         ports.put("dockerPort", getDockerPort());
         ports.put("dockerSslPort", getDockerSslPort());
         if (getEntity().getConfig(DockerInfrastructure.WEAVE_ENABLED)) {
-            // Best guess at available port, as Weave is started _after_ the
-            // DockerHost
+            // Best guess at available port, as Weave is started _after_ the DockerHost
             Integer weavePort = getEntity()
                     .getAttribute(DockerHost.DOCKER_INFRASTRUCTURE)
                     .getAttribute(DockerInfrastructure.WEAVE_INFRASTRUCTURE)
@@ -109,7 +109,7 @@ public class DockerHostSshDriver extends AbstractSoftwareProcessSshDriver implem
     /** {@inheritDoc} */
     @Override
     public String buildImage(String dockerFile, String name) {
-        if (ArchiveUtils.ArchiveType.UNKNOWN != ArchiveUtils.ArchiveType.of(dockerFile) || Urls.isDirectory(dockerFile)) {
+        if (!ArchiveType.UNKNOWN.equals(ArchiveType.of(dockerFile)) || Urls.isDirectory(dockerFile)) {
             ArchiveUtils.deploy(dockerFile, getMachine(), Os.mergePaths(getRunDir(), name));
             String baseImageId = buildDockerfileDirectory(name);
             log.info("Created base Dockerfile image with ID {}", baseImageId);
@@ -138,14 +138,17 @@ public class DockerHostSshDriver extends AbstractSoftwareProcessSshDriver implem
     }
 
     private Map<String, Object> getExtraTemplateSubstitutions(String imageName) {
-        Map<String, Object> templateSubstitutions = MutableMap.<String, Object> of("repository", getRepository(), "imageName", imageName);
+        Map<String, Object> templateSubstitutions = MutableMap.<String, Object>of(
+                "fullyQualifiedImageName", Os.mergePaths(getRepository(), imageName));
         DockerHost host = (DockerHost) getEntity();
         templateSubstitutions.putAll(host.getInfrastructure().getConfig(DockerInfrastructure.DOCKERFILE_SUBSTITUTIONS));
         return templateSubstitutions;
     }
 
     private String buildDockerfileDirectory(String name) {
-        String build = format("build --rm -t %s %s", Os.mergePaths(getRepository(), name), Os.mergePaths(getRunDir(), name));
+        String build = format("build --rm -t %s %s",
+                Os.mergePaths(getRepository(), name),
+                Os.mergePaths(getRunDir(), name));
         String stdout = ((DockerHost) getEntity()).runDockerCommandTimeout(build, Duration.minutes(20));
         String prefix = Strings.getFirstWordAfter(stdout, "Successfully built");
 
@@ -153,7 +156,9 @@ public class DockerHostSshDriver extends AbstractSoftwareProcessSshDriver implem
     }
 
     private String buildDockerfile(String dockerfile, String name) {
-        String build = format("build --rm -t %s - < %s", Os.mergePaths(getRepository(), name), Os.mergePaths(getRunDir(), name, dockerfile));
+        String build = format("build --rm -t %s - < %s",
+                Os.mergePaths(getRepository(), name),
+                Os.mergePaths(getRunDir(), name, dockerfile));
         String stdout = ((DockerHost) getEntity()).runDockerCommandTimeout(build, Duration.minutes(20));
         String prefix = Strings.getFirstWordAfter(stdout, "Successfully built");
 

--- a/docker/src/main/java/brooklyn/entity/container/docker/application/VanillaDockerApplication.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/application/VanillaDockerApplication.java
@@ -31,8 +31,8 @@ import brooklyn.util.time.Duration;
 import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
 
-@ImplementedBy(DockerfileApplicationImpl.class)
-public interface DockerfileApplication extends VanillaSoftwareProcess {
+@ImplementedBy(VanillaDockerApplicationImpl.class)
+public interface VanillaDockerApplication extends VanillaSoftwareProcess {
 
     @SetFromFlag("startTimeout")
     ConfigKey<Duration> START_TIMEOUT = ConfigKeys.newConfigKeyWithDefault(BrooklynConfigKeys.START_TIMEOUT, Duration.FIVE_MINUTES);
@@ -40,9 +40,15 @@ public interface DockerfileApplication extends VanillaSoftwareProcess {
     @SetFromFlag("dockerfileUrl")
     ConfigKey<String> DOCKERFILE_URL = DockerAttributes.DOCKERFILE_URL;
 
+    @SetFromFlag("imageName")
+    ConfigKey<String> IMAGE_NAME = DockerAttributes.DOCKER_IMAGE_NAME.getConfigKey();
+
+    @SetFromFlag("imageTag")
+    ConfigKey<String> IMAGE_TAG = DockerAttributes.DOCKER_IMAGE_TAG.getConfigKey();
+
     @SetFromFlag("openPorts")
-    ConfigKey<List<Integer>> CONTAINER_PORT_LIST = ConfigKeys.newConfigKey(
-            new TypeToken<List<Integer>>() { }, "docker.container.openPorts", "List of ports to open on the container for forwarding", ImmutableList.<Integer>of());
+    ConfigKey<List<Integer>> CONTAINER_PORT_LIST = ConfigKeys.newConfigKey(new TypeToken<List<Integer>>() {},
+            "docker.container.openPorts", "List of ports to open on the container for forwarding", ImmutableList.<Integer>of());
 
     DockerContainer getDockerContainer();
     DockerHost getDockerHost();

--- a/docker/src/main/java/brooklyn/entity/container/docker/application/VanillaDockerApplicationDriver.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/application/VanillaDockerApplicationDriver.java
@@ -17,6 +17,6 @@ package brooklyn.entity.container.docker.application;
 
 import brooklyn.entity.basic.SoftwareProcessDriver;
 
-public interface DockerfileApplicationDriver extends SoftwareProcessDriver {
+public interface VanillaDockerApplicationDriver extends SoftwareProcessDriver {
 
 }

--- a/docker/src/main/java/brooklyn/entity/container/docker/application/VanillaDockerApplicationImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/application/VanillaDockerApplicationImpl.java
@@ -28,9 +28,9 @@ import brooklyn.location.docker.DockerContainerLocation;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 
-public class DockerfileApplicationImpl extends SoftwareProcessImpl implements DockerfileApplication {
+public class VanillaDockerApplicationImpl extends SoftwareProcessImpl implements VanillaDockerApplication {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DockerfileApplication.class);
+    private static final Logger LOG = LoggerFactory.getLogger(VanillaDockerApplicationImpl.class);
 
     @Override
     public void init() {
@@ -59,8 +59,8 @@ public class DockerfileApplicationImpl extends SoftwareProcessImpl implements Do
     }
 
     @Override
-    public Class<? extends DockerfileApplicationDriver> getDriverInterface() {
-        return DockerfileApplicationDriver.class;
+    public Class<? extends VanillaDockerApplicationDriver> getDriverInterface() {
+        return VanillaDockerApplicationDriver.class;
     }
 
     @Override

--- a/docker/src/main/java/brooklyn/entity/container/docker/application/VanillaDockerApplicationSshDriver.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/application/VanillaDockerApplicationSshDriver.java
@@ -25,13 +25,13 @@ import brooklyn.location.basic.SshMachineLocation;
 import brooklyn.location.docker.DockerContainerLocation;
 
 /**
- * The SSH implementation of the {@link DockerfileApplicationDriver}.
+ * The SSH implementation of the {@link VanillaDockerApplicationDriver}.
  */
-public class DockerfileApplicationSshDriver extends AbstractSoftwareProcessSshDriver implements DockerfileApplicationDriver {
+public class VanillaDockerApplicationSshDriver extends AbstractSoftwareProcessSshDriver implements VanillaDockerApplicationDriver {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DockerfileApplication.class);
+    private static final Logger LOG = LoggerFactory.getLogger(VanillaDockerApplicationSshDriver.class);
 
-    public DockerfileApplicationSshDriver(DockerfileApplicationImpl entity, SshMachineLocation machine) {
+    public VanillaDockerApplicationSshDriver(VanillaDockerApplicationImpl entity, SshMachineLocation machine) {
         super(entity, machine);
     }
 
@@ -44,7 +44,7 @@ public class DockerfileApplicationSshDriver extends AbstractSoftwareProcessSshDr
     }
 
     public String getDockerfile() {
-        return getEntity().getConfig(DockerfileApplication.DOCKERFILE_URL);
+        return getEntity().getConfig(VanillaDockerApplication.DOCKERFILE_URL);
     }
 
     @Override

--- a/docker/src/main/java/brooklyn/entity/proxy/haproxy/HAProxyController.java
+++ b/docker/src/main/java/brooklyn/entity/proxy/haproxy/HAProxyController.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014 by Cloudsoft Corporation Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package brooklyn.entity.proxy.haproxy;
+
+import brooklyn.config.ConfigKey;
+import brooklyn.entity.basic.ConfigKeys;
+import brooklyn.entity.proxy.AbstractController;
+import brooklyn.entity.proxying.ImplementedBy;
+import brooklyn.util.flags.SetFromFlag;
+
+@ImplementedBy(HAProxyControllerImpl.class)
+public interface HAProxyController extends AbstractController {
+
+    @SetFromFlag("haProxyConfig")
+    ConfigKey<String> HAPROXY_CONFIG_TEMPLATE_URL = ConfigKeys.newStringConfigKey(
+            "haproxy.config.templateUrl",
+            "Configuration template file (in freemarker format) for HAProxyController",
+            "classpath://brooklyn/entity/proxy/haproxy/haproxy.cfg");
+
+    @SetFromFlag("backendMode")
+    ConfigKey<String> BACKEND_MODE = ConfigKeys.newStringConfigKey(
+            "haproxy.backend.mode", "The mode of the backend", "http");
+
+    @SetFromFlag("frontendMode")
+    ConfigKey<String> FRONTEND_MODE = ConfigKeys.newStringConfigKey(
+            "haproxy.frontend.mode", "The mode of the frontend", "http");
+
+    @SetFromFlag("bindAddress")
+    ConfigKey<String> BIND_ADDRESS = ConfigKeys.newStringConfigKey(
+            "haproxy.frontend.bind.address", "The address frontend should bind to. If unset all" +
+                    "IPv4 addresses on the server will be listened on.");
+
+}

--- a/docker/src/main/java/brooklyn/entity/proxy/haproxy/HAProxyControllerImpl.java
+++ b/docker/src/main/java/brooklyn/entity/proxy/haproxy/HAProxyControllerImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014 by Cloudsoft Corporation Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package brooklyn.entity.proxy.haproxy;
+
+import brooklyn.entity.proxy.AbstractControllerImpl;
+
+public class HAProxyControllerImpl extends AbstractControllerImpl implements HAProxyController {
+
+    @Override
+    protected void reconfigureService() {
+        getDriver().reconfigureService();
+    }
+
+    @Override
+    public void reload() {
+        reconfigureService();
+    }
+
+    @Override
+    public Class getDriverInterface() {
+        return HAProxyDriver.class;
+    }
+
+    @Override
+    public HAProxyDriver getDriver() {
+        return HAProxyDriver.class.cast(super.getDriver());
+    }
+
+    @Override
+    protected void connectSensors() {
+        super.connectSensors();
+        connectServiceUpIsRunning();
+    }
+
+    @Override
+    protected void disconnectSensors() {
+        disconnectServiceUpIsRunning();
+        super.disconnectSensors();
+    }
+}

--- a/docker/src/main/java/brooklyn/entity/proxy/haproxy/HAProxyDriver.java
+++ b/docker/src/main/java/brooklyn/entity/proxy/haproxy/HAProxyDriver.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014 by Cloudsoft Corporation Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package brooklyn.entity.proxy.haproxy;
+
+import brooklyn.entity.basic.SoftwareProcessDriver;
+
+public interface HAProxyDriver extends SoftwareProcessDriver {
+
+    void reconfigureService();
+
+}

--- a/docker/src/main/java/brooklyn/entity/proxy/haproxy/HAProxySshDriver.java
+++ b/docker/src/main/java/brooklyn/entity/proxy/haproxy/HAProxySshDriver.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2014 by Cloudsoft Corporation Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package brooklyn.entity.proxy.haproxy;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+
+import brooklyn.entity.Entity;
+import brooklyn.entity.basic.AbstractSoftwareProcessSshDriver;
+import brooklyn.entity.basic.EntityLocal;
+import brooklyn.entity.proxy.LoadBalancer;
+import brooklyn.location.basic.Machines;
+import brooklyn.location.basic.SshMachineLocation;
+import brooklyn.util.collections.MutableMap;
+import brooklyn.util.guava.Maybe;
+import brooklyn.util.os.Os;
+
+public class HAProxySshDriver extends AbstractSoftwareProcessSshDriver implements HAProxyDriver {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HAProxySshDriver.class);
+
+    public HAProxySshDriver(EntityLocal entity, SshMachineLocation machine) {
+        super(entity, machine);
+    }
+
+    @Override
+    public void install() {
+        throw new UnsupportedOperationException("Driver expected to be used in a container with HAProxy installed");
+    }
+
+    @Override
+    public void customize() {
+        reconfigureService();
+    }
+
+    @Override
+    public void launch() {
+        StringBuilder command = new StringBuilder(Os.mergePathsUnix(getInstallDir(), "haproxy"))
+                .append(" -D") // daemon
+                .append(" -p ").append(getPidFileLocation())
+                .append(" -f ").append(getConfigFileLocation())
+                // must be the last argument
+                .append(" -sf ").append(" $(cat ").append(getPidFileLocation()).append(")");
+        newScript(LAUNCHING)
+                .body.append(command)
+                .failOnNonZeroResultCode()
+                .execute();
+    }
+
+    @Override
+    public void stop() {
+        newScript(MutableMap.of(USE_PID_FILE, true), STOPPING).execute();
+    }
+
+    @Override
+    public boolean isRunning() {
+        return 0 == newScript(MutableMap.of(USE_PID_FILE, getPidFileLocation()), CHECK_RUNNING).execute();
+    }
+
+    public String getPidFileLocation() {
+        return Os.mergePathsUnix(getRunDir(), "pid");
+    }
+
+    @Override
+    public void reconfigureService() {
+        Map<Entity, String> targets = getEntity().getAttribute(HAProxyController.SERVER_POOL_TARGETS);
+        LOG.info("Reconfiguring {} with: {}", getEntity(), targets.values());
+        for (Entity server : targets.keySet()) {
+            Maybe<SshMachineLocation> machine = Machines.findUniqueSshMachineLocation(server.getLocations());
+            if (machine.isPresentAndNonNull()) {
+            }
+        }
+        Map<String, Object> substitutions = ImmutableMap.<String, Object>builder()
+                .put("port", getEntity().getConfig(LoadBalancer.PROXY_HTTP_PORT))
+                .build();
+        String template = getEntity().getConfig(HAProxyController.HAPROXY_CONFIG_TEMPLATE_URL);
+        copyTemplate(template, getConfigFileLocation(), true, substitutions);
+        launch();
+        LOG.debug("HAProxy re-configured on: {}", getEntity());
+    }
+
+    private String getConfigFileLocation() {
+        return Os.mergePathsUnix(getRunDir(), "haproxy.cfg");
+    }
+
+    // For use in templates
+    public String getFrontendMode() {
+        return getEntity().getConfig(HAProxyController.FRONTEND_MODE);
+    }
+
+    public String getBackendMode() {
+        return getEntity().getConfig(HAProxyController.BACKEND_MODE);
+    }
+
+    public String getBindAddress() {
+        String host = Optional.fromNullable(getEntity().getConfig(HAProxyController.BIND_ADDRESS)).or("");
+        Integer port = getEntity().getAttribute(HAProxyController.PROXY_HTTP_PORT);
+        return host + ":" + port;
+    }
+
+}

--- a/docker/src/main/java/brooklyn/location/docker/DockerContainerLocation.java
+++ b/docker/src/main/java/brooklyn/location/docker/DockerContainerLocation.java
@@ -127,6 +127,7 @@ public class DockerContainerLocation extends SshMachineLocation implements Suppo
         if (publicPort == null) {
             LOG.warn("Unable to map port {} for Container {}. Mappings: {}",
                     new Object[]{portNumber, containerId, Joiner.on(", ").withKeyValueSeparator("=").join(mapping)});
+            publicPort = -1;
         } else {
             LOG.debug("Docker mapped port {} to {} for Container {}", new Object[]{portNumber, publicPort, containerId});
         }
@@ -199,7 +200,9 @@ public class DockerContainerLocation extends SshMachineLocation implements Suppo
         if (DockerCallbacks.COMMIT.equalsIgnoreCase(command)) {
             String containerId = getOwner().getContainerId();
             String imageName = getOwner().getAttribute(DockerContainer.IMAGE_NAME);
-            String output = getOwner().getDockerHost().runDockerCommandTimeout(format("commit %s %s", containerId, Os.mergePaths(getRepository(), imageName)), Duration.minutes(20));
+            String output = getOwner().getDockerHost().runDockerCommandTimeout(
+                    format("commit %s %s", containerId, Os.mergePaths(getRepository(), imageName)),
+                    Duration.minutes(20));
             String imageId = DockerUtils.checkId(output);
             ((EntityLocal) getOwner().getRunningEntity()).setAttribute(DockerContainer.IMAGE_ID, imageId);
             ((EntityLocal) getOwner()).setAttribute(DockerContainer.IMAGE_ID, imageId);
@@ -257,7 +260,8 @@ public class DockerContainerLocation extends SshMachineLocation implements Suppo
 
     @Override
     public String getSubnetIp() {
-        String containerAddress = getOwner().getDockerHost().runDockerCommand("inspect --format={{.NetworkSettings.IPAddress}} " + getOwner().getContainerId());
+        String containerAddress = getOwner().getDockerHost().runDockerCommand(
+                "inspect --format={{.NetworkSettings.IPAddress}} " + getOwner().getContainerId());
         return containerAddress.trim();
     }
 

--- a/docker/src/main/java/brooklyn/location/docker/DockerHostLocation.java
+++ b/docker/src/main/java/brooklyn/location/docker/DockerHostLocation.java
@@ -78,7 +78,6 @@ import com.google.common.collect.Maps;
 public class DockerHostLocation extends AbstractLocation implements MachineProvisioningLocation<DockerContainerLocation>, DockerVirtualLocation,
         DynamicLocation<DockerHost, DockerHostLocation>, Closeable {
 
-    /** serialVersionUID */
     private static final long serialVersionUID = -1453203257759956820L;
 
     private static final Logger LOG = LoggerFactory.getLogger(DockerHostLocation.class);
@@ -264,7 +263,7 @@ public class DockerHostLocation extends AbstractLocation implements MachineProvi
                     !DockerUtils.BLACKLIST_URL_SENSOR_NAMES.contains(sensor.getName())) {
                 AttributeSensor<String> target = DockerUtils.<String>mappedSensor(sensor);
                 entity.addEnricher(dockerHost.getSubnetTier().uriTransformingEnricher(
-                        EntityAndAttribute.supplier(entity, sensor), target));
+                        EntityAndAttribute.create(entity, sensor), target));
                 Set<Hint<?>> hints = RendererHints.getHintsFor(sensor);
                 for (Hint<?> hint : hints) {
                     RendererHints.register(target, (NamedActionWithUrl) hint);
@@ -275,7 +274,7 @@ public class DockerHostLocation extends AbstractLocation implements MachineProvi
             } else if (PortAttributeSensorAndConfigKey.class.isAssignableFrom(sensor.getClass())) {
                 AttributeSensor<String> target = DockerUtils.mappedPortSensor((PortAttributeSensorAndConfigKey) sensor);
                 entity.addEnricher(dockerHost.getSubnetTier().hostAndPortTransformingEnricher(
-                        EntityAndAttribute.supplier(entity, sensor), target));
+                        EntityAndAttribute.create(entity, sensor), target));
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Mapped port sensor: origin={}, mapped={}", sensor.getName(), target.getName());
                 }

--- a/docker/src/main/resources/brooklyn/entity/container/docker/SshdDockerfile
+++ b/docker/src/main/resources/brooklyn/entity/container/docker/SshdDockerfile
@@ -18,7 +18,7 @@
 #
 # VERSION 0.0.4
 
-FROM ${repository}/${imageName}
+FROM ${fullyQualifiedImageName}
 MAINTAINER Cloudsoft "brooklyn@cloudsoftcorp.com"
 
 # setup locale

--- a/docker/src/main/resources/brooklyn/entity/proxy/haproxy/haproxy.cfg
+++ b/docker/src/main/resources/brooklyn/entity/proxy/haproxy/haproxy.cfg
@@ -1,0 +1,23 @@
+[#ftl]
+global
+    maxconn 256
+
+defaults
+    mode http
+    timeout connect 5000ms
+    timeout client 50000ms
+    timeout server 50000ms
+    stats enable
+
+frontend http-in
+    bind ${driver.bindAddress}
+    mode ${driver.frontendMode}
+    default_backend servers
+
+backend servers
+    mode ${driver.backendMode}
+[#if entity.serverPoolAddresses?has_content]
+  [#list entity.serverPoolAddresses as address]
+    server ${address} ${address}
+  [/#list]
+[/#if]

--- a/docker/src/test/java/brooklyn/entity/container/docker/AbstractClockerIntegrationTest.java
+++ b/docker/src/test/java/brooklyn/entity/container/docker/AbstractClockerIntegrationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014 by Cloudsoft Corporation Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package brooklyn.entity.container.docker;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+
+import brooklyn.entity.BrooklynAppLiveTestSupport;
+import brooklyn.entity.basic.Entities;
+import brooklyn.launcher.BrooklynLauncher;
+import brooklyn.location.Location;
+import brooklyn.util.text.Strings;
+
+public class AbstractClockerIntegrationTest extends BrooklynAppLiveTestSupport {
+
+    private static final String DEFAULT_LOCATION_SPEC = "jclouds:softlayer:ams01";
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractClockerIntegrationTest.class);
+
+    protected BrooklynLauncher launcher;
+    protected Location testLocation;
+    protected String testLocationSpec;
+
+    @BeforeClass(alwaysRun = true)
+    @Parameters({"locationSpec"})
+    public void setSpec(@Optional String locationSpec) {
+        testLocationSpec = Strings.isBlank(locationSpec) ? DEFAULT_LOCATION_SPEC : locationSpec;
+        LOG.info("Running {} in {}", getClass().getName(), testLocationSpec);
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() throws Exception {
+        super.setUp();
+        testLocation = mgmt.getLocationRegistry().resolve(testLocationSpec);
+        launcher = BrooklynLauncher.newInstance()
+                .managementContext(mgmt)
+                .start();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() throws Exception {
+        if (mgmt != null) Entities.destroyAll(mgmt);
+        if (launcher != null) launcher.terminate();
+    }
+
+}

--- a/docker/src/test/java/brooklyn/entity/container/docker/DockerInfrastructureLiveTest.java
+++ b/docker/src/test/java/brooklyn/entity/container/docker/DockerInfrastructureLiveTest.java
@@ -53,36 +53,7 @@ import brooklyn.util.time.Duration;
 /**
  * Brooklyn managed basic Docker infrastructure.
  */
-public class DockerInfrastructureLiveTest extends BrooklynAppLiveTestSupport  {
-
-    private static final String DEFAULT_LOCATION_SPEC = "jclouds:softlayer:ams01";
-    private static final Logger LOG = LoggerFactory.getLogger(DockerInfrastructureLiveTest.class);
-
-    private BrooklynLauncher launcher;
-    private Location testLocation;
-    private String testLocationSpec;
-
-    @BeforeClass(alwaysRun = true)
-    @Parameters({"locationSpec"})
-    public void setSpec(@Optional String locationSpec) {
-        testLocationSpec = Strings.isBlank(locationSpec) ? DEFAULT_LOCATION_SPEC : locationSpec;
-        LOG.info("Running {} in {}", getClass().getName(), testLocationSpec);
-    }
-
-    @BeforeMethod(alwaysRun = true)
-    public void setUp() throws Exception {
-        super.setUp();
-        testLocation = mgmt.getLocationRegistry().resolve(testLocationSpec);
-        launcher = BrooklynLauncher.newInstance()
-                .managementContext(mgmt)
-                .start();
-    }
-
-    @AfterMethod(alwaysRun = true)
-    public void tearDown() throws Exception {
-        if (mgmt != null) Entities.destroyAll(mgmt);
-        if (launcher != null) launcher.terminate();
-    }
+public class DockerInfrastructureLiveTest extends AbstractClockerIntegrationTest {
 
     @Test(groups="Live")
     public void testRegistersLocation() throws Exception {

--- a/docker/src/test/java/brooklyn/entity/container/docker/DockerInfrastructureTests.java
+++ b/docker/src/test/java/brooklyn/entity/container/docker/DockerInfrastructureTests.java
@@ -43,7 +43,7 @@ public class DockerInfrastructureTests {
     public static DockerInfrastructure deployAndWaitForDockerInfrastructure(TestApplication app, Location location) {
         DockerInfrastructure dockerInfrastructure = app.createAndManageChild(EntitySpec.create(DockerInfrastructure.class)
                 .configure(DockerInfrastructure.DOCKER_HOST_CLUSTER_MIN_SIZE, 1)
-                .configure(DockerInfrastructure.WEAVE_ENABLED, false)
+                .configure(DockerInfrastructure.WEAVE_ENABLED, true)
                 .displayName("Docker Infrastructure"));
         LOG.info("Starting {} in {}", dockerInfrastructure, location);
         app.start(ImmutableList.of(location));

--- a/docker/src/test/java/brooklyn/entity/container/docker/DockerInfrastructureTests.java
+++ b/docker/src/test/java/brooklyn/entity/container/docker/DockerInfrastructureTests.java
@@ -47,7 +47,7 @@ public class DockerInfrastructureTests {
                 .displayName("Docker Infrastructure"));
         LOG.info("Starting {} in {}", dockerInfrastructure, location);
         app.start(ImmutableList.of(location));
-        LOG.info("Waiting {} for {} to have started", Duration.FIVE_MINUTES, dockerInfrastructure);
+        LOG.info("Waiting {} for {} to have started", Duration.TWO_MINUTES, dockerInfrastructure);
         EntityTestUtils.assertAttributeEqualsEventually(ImmutableMap.of("timeout", Duration.FIVE_MINUTES),
                 dockerInfrastructure, Attributes.SERVICE_UP, true);
 
@@ -60,5 +60,7 @@ public class DockerInfrastructureTests {
         EntityTestUtils.assertAttributeEqualsEventually(deployment, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
         EntityTestUtils.assertAttributeEqualsEventually(dockerInfrastructure, DockerInfrastructure.DOCKER_CONTAINER_COUNT,
                 existingCount + 1);
+
+        deployment.stop();
     }
 }

--- a/docker/src/test/java/brooklyn/entity/container/docker/DockerInfrastructureTests.java
+++ b/docker/src/test/java/brooklyn/entity/container/docker/DockerInfrastructureTests.java
@@ -40,7 +40,7 @@ public class DockerInfrastructureTests {
 
     private DockerInfrastructureTests() {}
 
-    public static void testDeploysTrivialApplication(TestApplication app, Location location) {
+    public static DockerInfrastructure deployAndWaitForDockerInfrastructure(TestApplication app, Location location) {
         DockerInfrastructure dockerInfrastructure = app.createAndManageChild(EntitySpec.create(DockerInfrastructure.class)
                 .configure(DockerInfrastructure.DOCKER_HOST_CLUSTER_MIN_SIZE, 1)
                 .configure(DockerInfrastructure.WEAVE_ENABLED, false)
@@ -50,7 +50,11 @@ public class DockerInfrastructureTests {
         LOG.info("Waiting {} for {} to have started", Duration.TWO_MINUTES, dockerInfrastructure);
         EntityTestUtils.assertAttributeEqualsEventually(ImmutableMap.of("timeout", Duration.FIVE_MINUTES),
                 dockerInfrastructure, Attributes.SERVICE_UP, true);
+        return dockerInfrastructure;
+    }
 
+    public static void testDeploysTrivialApplication(TestApplication app, Location location) {
+        DockerInfrastructure dockerInfrastructure = deployAndWaitForDockerInfrastructure(app, location);
         int existingCount = dockerInfrastructure.getAttribute(DockerInfrastructure.DOCKER_CONTAINER_COUNT);
 
         TestApplication deployment = ApplicationBuilder.newManagedApp(TestApplication.class, app.getManagementContext());

--- a/docker/src/test/java/brooklyn/entity/proxy/haproxy/HAProxyIntegrationTest.java
+++ b/docker/src/test/java/brooklyn/entity/proxy/haproxy/HAProxyIntegrationTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2014 by Cloudsoft Corporation Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package brooklyn.entity.proxy.haproxy;
+
+import static brooklyn.test.HttpTestUtils.assertHttpStatusCodeEventuallyEquals;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import brooklyn.entity.Entity;
+import brooklyn.entity.basic.ApplicationBuilder;
+import brooklyn.entity.basic.Attributes;
+import brooklyn.entity.basic.Lifecycle;
+import brooklyn.entity.basic.SoftwareProcess;
+import brooklyn.entity.container.DockerAttributes;
+import brooklyn.entity.container.docker.AbstractClockerIntegrationTest;
+import brooklyn.entity.container.docker.DockerInfrastructure;
+import brooklyn.entity.container.docker.DockerInfrastructureTests;
+import brooklyn.entity.group.DynamicCluster;
+import brooklyn.entity.proxying.EntitySpec;
+import brooklyn.entity.webapp.JavaWebAppService;
+import brooklyn.entity.webapp.WebAppService;
+import brooklyn.entity.webapp.tomcat.TomcatServer;
+import brooklyn.event.AttributeSensor;
+import brooklyn.event.Sensor;
+import brooklyn.event.basic.Sensors;
+import brooklyn.test.EntityTestUtils;
+import brooklyn.test.TestResourceUnavailableException;
+import brooklyn.test.entity.TestApplication;
+
+public class HAProxyIntegrationTest extends AbstractClockerIntegrationTest {
+
+    private EntitySpec<HAProxyController> haProxySpec() {
+        return EntitySpec.create(HAProxyController.class)
+                .configure(DockerAttributes.DOCKER_IMAGE_NAME, "haproxy")
+                .configure(DockerAttributes.DOCKER_IMAGE_TAG, "latest")
+                .configure(SoftwareProcess.INSTALL_DIR, "/usr/local/sbin/")
+                .configure(SoftwareProcess.RUN_DIR, "/usr/local/etc/haproxy/");
+    }
+
+    private EntitySpec<TomcatServer> tomcatSpec() {
+        return EntitySpec.create(TomcatServer.class);
+        // Had SSH connection issues when trying to use the configuration below.
+        //.configure(DockerAttributes.DOCKER_IMAGE_NAME, "tomcat")
+        //.configure(DockerAttributes.DOCKER_IMAGE_TAG, "7-jre7")
+        //.configure(SoftwareProcess.INSTALL_DIR, "/usr/local/tomcat/")
+        //.configure(SoftwareProcess.EXPANDED_INSTALL_DIR, "/usr/local/tomcat/")
+        //.configure(SoftwareProcess.RUN_DIR, "/usr/local/tomcat/");
+    }
+
+    private String getTestWar() {
+        TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), "/hello-world.war");
+        return "classpath://hello-world.war";
+    }
+
+    private AttributeSensor<String> mappedSensor(Sensor<String> sensor) {
+        return Sensors.newStringSensor("mapped." + sensor.getName());
+    }
+
+    @Test(groups = "Integration")
+    public void testContainerFromImageName() {
+        DockerInfrastructure infrastructure = DockerInfrastructureTests.deployAndWaitForDockerInfrastructure(app, testLocation);
+
+        TestApplication testApp = ApplicationBuilder.newManagedApp(TestApplication.class, app.getManagementContext());
+        DynamicCluster serverPool = testApp.createAndManageChild(EntitySpec.create(DynamicCluster.class)
+                .configure(DynamicCluster.MEMBER_SPEC, tomcatSpec())
+                .configure(DynamicCluster.INITIAL_SIZE, 1)
+                .configure(JavaWebAppService.ROOT_WAR, getTestWar()));
+
+        HAProxyController hap = testApp.createAndManageChild(haProxySpec()
+                .configure(HAProxyController.SERVER_POOL, serverPool)
+                .configure(HAProxyController.HOSTNAME_SENSOR, Attributes.SUBNET_HOSTNAME));
+        testApp.start(ImmutableList.of(infrastructure.getDynamicLocation()));
+        EntityTestUtils.assertAttributeEqualsEventually(hap, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+
+        // URLs reachable
+        assertHttpStatusCodeEventuallyEquals(hap.getAttribute(mappedSensor(HAProxyController.ROOT_URL)), 200);
+        for (Entity member : serverPool.getMembers()) {
+            assertHttpStatusCodeEventuallyEquals(member.getAttribute(mappedSensor(WebAppService.ROOT_URL)), 200);
+        }
+
+        testApp.stop();
+    }
+
+}

--- a/examples/src/main/assembly/files/blueprints/docker-cloud.yaml
+++ b/examples/src/main/assembly/files/blueprints/docker-cloud.yaml
@@ -23,7 +23,6 @@ services:
     weave.version: "0.8.0"
     entity.dynamicLocation.name: "my-docker-cloud"
     docker.host.cluster.initial.size: 2
-    docker.host.register: false
     docker.container.cluster.headroom.count: 4
     weave.enabled: true
     docker.policy.ha.enable: true

--- a/examples/src/main/assembly/files/blueprints/docker-localhost.yaml
+++ b/examples/src/main/assembly/files/blueprints/docker-localhost.yaml
@@ -24,6 +24,5 @@ services:
     docker.version: "1.2"
     entity.dynamicLocation.name: "my-docker-cloud"
     docker.host.initial.size: 1
-    docker.host.register: false
     weave.enabled: false
     install.skip: false

--- a/examples/src/main/assembly/files/blueprints/dockerfile-mysql.yaml
+++ b/examples/src/main/assembly/files/blueprints/dockerfile-mysql.yaml
@@ -28,3 +28,4 @@ services:
       MYSQL_ROOT_PASSWORD: "s3cr3t"
 
 # mysql-5.6.tgz contains ./docker-entrypoint.sh and ./Dockerfile from GitHub
+# https://github.com/docker-library/mysql

--- a/examples/src/main/assembly/files/blueprints/dockerfile-mysql.yaml
+++ b/examples/src/main/assembly/files/blueprints/dockerfile-mysql.yaml
@@ -18,7 +18,7 @@ origin: "https://registry.hub.docker.com/_/mysql/"
 locations:
 - my-docker-cloud
 services:
-- serviceType: brooklyn.entity.container.docker.application.DockerfileApplication
+- serviceType: brooklyn.entity.container.docker.application.VanillaDockerApplicationion
   id: mysql
   name: "MySQL"
   brooklyn.config:

--- a/examples/src/main/assembly/files/blueprints/tomcat-cluster-with-mysql.yaml
+++ b/examples/src/main/assembly/files/blueprints/tomcat-cluster-with-mysql.yaml
@@ -29,8 +29,9 @@ services:
     proxy.http.port: "8000+"
     java.sysprops:
       brooklyn.example.db.url: >
-        $brooklyn:formatString("jdbc:%s%s?user=%s&password=%s",
-        component("mysql").attributeWhenReady("datastore.url"),
+        $brooklyn:formatString("jdbc:mysql://%s:%s/%s?user=%s&password=%s",
+        component("mysql").attributeWhenReady("host.subnet.address"),
+        component("mysql").attributeWhenReady("mysql.port"),
         "visitors", "brooklyn", "br00k11n")
     memberSpec:
       $brooklyn:entitySpec:
@@ -48,10 +49,14 @@ services:
         type: brooklyn.entity.webapp.DynamicWebAppCluster
     controlleddynamicwebappcluster.controllerSpec:
       $brooklyn:entitySpec:
-        type: brooklyn.entity.proxy.nginx.NginxController
+        type: brooklyn.entity.proxy.haproxy.HAProxyController
         brooklyn.config:
+          docker.image.name: haproxy
+          docker.image.tag: latest
+          install.dir: /usr/local/sbin/
+          run.dir: /usr/local/etc/haproxy/
           member.sensor.hostname: "host.subnet.hostname"
-- serviceType: brooklyn.entity.database.mysql.MySqlNode
+- type: brooklyn.entity.database.mysql.MySqlNode
   id: mysql
   name: MySQL Database
   brooklyn.config:

--- a/examples/src/main/java/brooklyn/clocker/example/SimpleDockerCluster.java
+++ b/examples/src/main/java/brooklyn/clocker/example/SimpleDockerCluster.java
@@ -22,12 +22,12 @@ import brooklyn.entity.basic.AbstractApplication;
 import brooklyn.entity.basic.ConfigKeys;
 import brooklyn.entity.basic.Entities;
 import brooklyn.entity.container.DockerAttributes;
-import brooklyn.entity.container.docker.application.DockerfileApplication;
+import brooklyn.entity.container.docker.application.VanillaDockerApplication;
 import brooklyn.entity.group.DynamicCluster;
 import brooklyn.entity.proxying.EntitySpec;
 
 /**
- * Brooklyn managed {@link DockerfileApplication} cluster
+ * Brooklyn managed {@link VanillaDockerApplication} cluster
  */
 @Catalog(name="Application Cluster",
         description="Simple cluster of applications defined by a Dockerfile",
@@ -45,8 +45,8 @@ public class SimpleDockerCluster extends AbstractApplication {
         addChild(EntitySpec.create(DynamicCluster.class)
                 .displayName("Docker Application Cluster")
                 .configure(DynamicCluster.INITIAL_SIZE, getConfig(INITIAL_SIZE))
-                .configure(DynamicCluster.MEMBER_SPEC, EntitySpec.create(DockerfileApplication.class)
-                        .configure(DockerfileApplication.DOCKERFILE_URL, Entities.getRequiredUrlConfig(this, DOCKERFILE_URL))));
+                .configure(DynamicCluster.MEMBER_SPEC, EntitySpec.create(VanillaDockerApplication.class)
+                        .configure(VanillaDockerApplication.DOCKERFILE_URL, Entities.getRequiredUrlConfig(this, DOCKERFILE_URL))));
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,24 @@
 
         <plugins>
             <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>2.6.1</version>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <directory>.</directory>
+                            <includes>
+                                <include>brooklyn*.log</include>
+                                <include>brooklyn*.log.*</include>
+                                <include>stacktrace.log</include>
+                                <include>test-output</include>
+                                <include>prodDb.*</include>
+                            </includes>
+                        </fileset>
+                    </filesets>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-eclipse-plugin</artifactId>
                 <configuration>
                     <additionalProjectnatures>


### PR DESCRIPTION
* Entities can be run from named images. 
* Adds an HAProxy entity

The following should work:
```yaml
services:
- type: brooklyn.entity.proxy.haproxy.HAProxyController
  brooklyn.config:
    imageName: haproxy
    imageTag: latest
    installDir: /usr/local/sbin/
    runDir: /usr/local/etc/haproxy/
```

See also `HAProxyIntegrationTest`.

This is submitted for review expecting that a few adjustments will be necessary. For one, I haven't altered `DockerUtils.imageName` yet.
