### PR TITLE
Blueprint testing

### DIFF
--- a/docker/src/main/java/brooklyn/location/docker/DockerContainerLocation.java
+++ b/docker/src/main/java/brooklyn/location/docker/DockerContainerLocation.java
@@ -16,6 +16,7 @@
 package brooklyn.location.docker;
 
 import static brooklyn.util.ssh.BashCommands.sudo;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
 
 import java.io.IOException;
@@ -260,8 +261,9 @@ public class DockerContainerLocation extends SshMachineLocation implements Suppo
 
     @Override
     public String getSubnetIp() {
+        String containerId = checkNotNull(getOwner().getContainerId(), "containerId");
         String containerAddress = getOwner().getDockerHost().runDockerCommand(
-                "inspect --format={{.NetworkSettings.IPAddress}} " + getOwner().getContainerId());
+                "inspect --format={{.NetworkSettings.IPAddress}} " + containerId);
         return containerAddress.trim();
     }
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -32,6 +32,10 @@
         Clocker example Brooklyn blueprints for Docker.
     </description>
 
+    <properties>
+        <testLocation>jclouds:softlayer:ams01</testLocation>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.brooklyn.clocker</groupId>
@@ -62,10 +66,51 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>${testng.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-rest-client</artifactId>
+            <version>${brooklyn.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-test-support</artifactId>
+            <version>${brooklyn.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-core</artifactId>
+            <version>${brooklyn.version}</version>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
     </dependencies>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.18.1</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*IntegrationTest.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
@@ -106,5 +151,122 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>AcceptanceTest</id>
+            <activation>
+                <property>
+                    <name>Integration</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>1.9.1</version>
+                        <executions>
+                            <execution>
+                                <id>reserve-brooklyn-port</id>
+                                <!-- Want a port to be reserved before resources are processed. -->
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>reserve-network-port</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <portNames>
+                                <portName>brooklyn.console</portName>
+                            </portNames>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.3.2</version>
+                        <executions>
+                            <execution>
+                                <id>run-brooklyn-server</id>
+                                <phase>pre-integration-test</phase>
+                                <goals><goal>exec</goal></goals>
+                                <configuration>
+                                    <executable>${project.build.testOutputDirectory}/run-brooklyn.sh</executable>
+                                    <arguments>
+                                        <argument>${project.build.directory}/brooklyn-clocker-dist/brooklyn-clocker/bin/brooklyn.sh</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- maven-resources-plugin does not preserve permissions when copying files. -->
+                    <!-- https://jira.codehaus.org/browse/MRESOURCES-132 -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>1.8</version>
+                        <executions>
+                            <execution>
+                                <id>fix-permissions-on-run.sh</id>
+                                <phase>process-test-resources</phase>
+                                <configuration>
+                                    <target>
+                                        <chmod file="target/test-classes/run-brooklyn.sh" perm="755"/>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.18.1</version>
+                        <configuration>
+                            <parallel>methods</parallel>
+                            <threadCount>3</threadCount>
+                            <includes>
+                                <include>**/*IntegrationTest.java</include>
+                            </includes>
+                            <systemPropertyVariables>
+                                <brooklyn>http://localhost:${brooklyn.console}</brooklyn>
+                            </systemPropertyVariables>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-tests</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.brooklyn.maven</groupId>
+                        <artifactId>brooklyn-maven-plugin</artifactId>
+                        <version>0.2.0-SNAPSHOT</version>
+                        <configuration>
+                            <server>http://localhost:${brooklyn.console}</server>
+                            <blueprint>${project.build.testOutputDirectory}/test-docker-cloud.yaml</blueprint>
+                            <!-- Fifteen minutes for slow clouds to provision. -->
+                            <timeout>15</timeout>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>deploy-docker-cloud</id>
+                                <goals>
+                                    <goal>deploy</goal>
+                                    <goal>stop-brooklyn</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/examples/src/main/assembly/assembly.xml
+++ b/examples/src/main/assembly/assembly.xml
@@ -19,6 +19,7 @@
         xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
     <id>dist</id>
     <formats>
+        <format>dir</format>
         <format>tar.gz</format>
     </formats>
 

--- a/examples/src/test/java/blueprints/BlueprintIntegrationTest.java
+++ b/examples/src/test/java/blueprints/BlueprintIntegrationTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2014 by Cloudsoft Corporation Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package blueprints;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Files;
+
+import brooklyn.rest.client.BrooklynApi;
+import brooklyn.rest.domain.Status;
+import brooklyn.rest.domain.TaskSummary;
+import brooklyn.util.exceptions.Exceptions;
+import brooklyn.util.repeat.Repeater;
+import brooklyn.util.time.Duration;
+
+public class BlueprintIntegrationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BlueprintIntegrationTest.class);
+    private static final String BLUEPRINT_DIRECTORY = "src/main/assembly/files/blueprints/";
+
+    String brooklynUrl;
+
+    @BeforeClass(alwaysRun = true)
+    @Parameters({"brooklyn"})
+    public void setSpec(String brooklyn) {
+        brooklynUrl = brooklyn;
+        LOG.info("Running {} in {}", getClass().getName(), brooklyn);
+    }
+
+    public void testBlueprintDeploys(String name) {
+        BrooklynApi api = new BrooklynApi(brooklynUrl);
+        LOG.info("Testing " + name);
+        String blueprint = loadBlueprint(name);
+        Response r = api.getApplicationApi().createFromYaml(blueprint);
+        final TaskSummary task = BrooklynApi.getEntity(r, TaskSummary.class);
+        final String application = task.getEntityId();
+        try {
+            assertAppStatusEventually(api, application, Status.RUNNING);
+        } finally {
+            LOG.info("Stopping {} (deployed from {})", application, name);
+            api.getEffectorApi().invoke(application, application, "stop", "never",
+                    ImmutableMap.<String, Object>of());
+        }
+    }
+
+    @Test(groups = "Integration")
+    public void testNodeJsTodo() {
+        testBlueprintDeploys(BLUEPRINT_DIRECTORY + "nodejs-todo.yaml");
+    }
+
+    @Test(groups = "Integration")
+    public void testCouchbase() {
+        testBlueprintDeploys(BLUEPRINT_DIRECTORY + "couchbase.yaml");
+    }
+
+    @Test(groups = "Integration")
+    public void testCouchbaseWithPillofight() {
+        testBlueprintDeploys(BLUEPRINT_DIRECTORY + "couchbase-with-pillowfight.yaml");
+    }
+
+    @Test(groups = "Integration")
+    public void testDockerfilMysql() {
+        testBlueprintDeploys(BLUEPRINT_DIRECTORY + "dockerfile-mysql.yaml");
+    }
+
+    @Test(groups = "Integration")
+    public void testRiakWebappCluster() {
+        testBlueprintDeploys(BLUEPRINT_DIRECTORY + "riak-webapp-cluster.yaml");
+    }
+
+    @Test(groups = "Integration")
+    public void testTomcatApplication() {
+        testBlueprintDeploys(BLUEPRINT_DIRECTORY + "tomcat-application.yaml");
+    }
+
+    @Test(groups = "Integration")
+    public void testTomcatApplicationWithVolumes() {
+        testBlueprintDeploys(BLUEPRINT_DIRECTORY + "tomcat-application-with-volumes.yaml");
+    }
+
+    @Test(groups = "Integration")
+    public void testTomcatClusterWithMysql() {
+        testBlueprintDeploys(BLUEPRINT_DIRECTORY + "tomcat-cluster-with-mysql.yaml");
+    }
+
+    @Test(groups = "Integration")
+    public void testTomcatSolrApplication() {
+        testBlueprintDeploys(BLUEPRINT_DIRECTORY + "tomcat-solr-application.yaml");
+    }
+
+    private String loadBlueprint(String name) {
+        try {
+            return Joiner.on('\n').join(Files.readLines(new File(name), Charsets.UTF_8));
+        } catch (IOException e) {
+            throw Exceptions.propagate(e);
+        }
+    }
+
+    /**
+     * Polls Brooklyn until the given application has the given status. Quits early if the application's
+     * status is {@link brooklyn.rest.domain.Status#ERROR} or {@link brooklyn.rest.domain.Status#UNKNOWN}
+     * and desiredStatus is something else.
+     * @return the final polled status
+     */
+    protected Status assertAppStatusEventually(final BrooklynApi api, final String application, final Status desiredStatus) {
+        final AtomicReference<Status> appStatus = new AtomicReference<Status>(Status.UNKNOWN);
+        final Duration timeout = Duration.of(10, TimeUnit.MINUTES);
+        final boolean shortcutOnError = !Status.ERROR.equals(desiredStatus) && !Status.UNKNOWN.equals(desiredStatus);
+        LOG.info("Waiting " + timeout + " for application " + application + " to be " + desiredStatus);
+        boolean finalAppStatusKnown = Repeater.create("Waiting for application " + application + " status to be " + desiredStatus)
+                .every(Duration.FIVE_SECONDS)
+                .limitTimeTo(timeout)
+                .rethrowExceptionImmediately()
+                .until(new Callable<Boolean>() {
+                    @Override
+                    public Boolean call() throws Exception {
+                        Status status = api.getApplicationApi().get(application).getStatus();
+                        LOG.debug("Application " + application + " status is: " + status);
+                        appStatus.set(status);
+                        return desiredStatus.equals(status) || (shortcutOnError &&
+                                (Status.ERROR.equals(status) || Status.UNKNOWN.equals(status)));
+                    }
+                })
+                .run();
+        if (appStatus.get().equals(desiredStatus)) {
+            LOG.info("Application " + application + " is " + desiredStatus.name());
+        } else {
+            String message = "Application is not " + desiredStatus.name() + " within " + timeout +
+                    ". Status is: " + appStatus.get();
+            LOG.error(message);
+            throw new RuntimeException(message);
+        }
+        return appStatus.get();
+    }
+
+}

--- a/examples/src/test/resources/run-brooklyn.sh
+++ b/examples/src/test/resources/run-brooklyn.sh
@@ -1,0 +1,27 @@
+#! /usr/bin/env bash
+set -e
+
+PORT="${brooklyn.console}"
+URL="http://localhost:${PORT}"
+
+$1 launch --port "$PORT" --persist disabled 2>&1 | tee brooklyn.log > /dev/null 2>&1 &
+
+# Wait for the launched server to answer.
+MAX_POLLS=10
+POLL_WAIT=2
+MAX_WAIT=$((MAX_POLLS*POLL_WAIT))
+
+echo "Waiting up to ${MAX_WAIT}s for server to respond at ${URL}"
+
+ATTEMPT=0
+while [ "$ATTEMPT" -lt "$MAX_POLLS" ]; do
+    if $(curl "$URL" > /dev/null 2>&1); then
+        echo "Ready"
+        exit 0
+    fi
+    ATTEMPT=$((ATTEMPT+1))
+    sleep "$POLL_WAIT"
+done
+
+echo "Brooklyn not responding after ${MAX_WAIT}s"
+exit 1

--- a/examples/src/test/resources/test-docker-cloud.yaml
+++ b/examples/src/test/resources/test-docker-cloud.yaml
@@ -1,0 +1,32 @@
+# Copyright 2014 by Cloudsoft Corporation Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: test-docker-cloud
+name: "Docker Infrastructure for tests"
+origin: "https://github.com/brooklyncentral/clocker/"
+
+description: >
+  Used in acceptance tests.
+
+location: ${testLocation}
+
+services:
+- serviceType: brooklyn.entity.container.docker.DockerInfrastructure
+  id: infrastructure
+  brooklyn.config:
+    docker.version: "1.2"
+    entity.dynamicLocation.name: "my-docker-cloud"
+    docker.host.initial.size: 1
+    weave.enabled: true
+    install.skip: false


### PR DESCRIPTION
See the comments on b55bafa for details. Tests run three at a time and assert that a particular blueprint can reach the `RUNNING` state within a fixed period. They expect each blueprint to define a location called `my-docker-cloud`.

I've found that this command works well for ongoing development:
```
mvn clean install -DIntegration -DtestLocation='byon:(hosts="...")' -Dit.test=BlueprintIntegrationTest#testSomeSpecificBlueprint
```
Note it's `-DIntegration` rather than `-PIntegration`. I couldn't get Maven to merge the parent's profile configuration so it's a different profile that's activated when the property exists. The `testLocation` argument modifies the target location for Clocker.

Maven's `-fae` argument (fail at end) is also useful when testing all blueprints.

The test blueprint runs a single `DockerHost`. The three-at-a-time configuration means this host is taxed fairly well.

Results from a full run:
```
Results :

Failed tests:
  BlueprintIntegrationTest.testCouchbase:81->testBlueprintDeploys:66->assertAppStatusEventually:159 Runtime
  BlueprintIntegrationTest.testCouchbaseWithPillofight:86->testBlueprintDeploys:66->assertAppStatusEventually:159 Runtime
  BlueprintIntegrationTest.testRiakWebappCluster:96->testBlueprintDeploys:66->assertAppStatusEventually:159 Runtime
  BlueprintIntegrationTest.testTomcatClusterWithMysql:111->testBlueprintDeploys:66->assertAppStatusEventually:159 Runtime

Tests run: 9, Failures: 4, Errors: 0, Skipped: 0
```
