### PR TITLE
Keep the last docker host when its last docker container is removed

### DIFF
--- a/docker/src/main/java/brooklyn/location/docker/DockerLocation.java
+++ b/docker/src/main/java/brooklyn/location/docker/DockerLocation.java
@@ -215,7 +215,9 @@ public class DockerLocation extends AbstractLocation implements DockerVirtualLoc
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Empty Docker host: {}", host);
                 }
-                if (getOwner().config().get(DockerInfrastructure.REMOVE_EMPTY_DOCKER_HOSTS)) {
+
+                // Remove hosts when it has no containers, except for the last one
+                if (getOwner().config().get(DockerInfrastructure.REMOVE_EMPTY_DOCKER_HOSTS) && set.size() > 1) {
                     LOG.info("Removing empty Docker host: {}", host);
                     remove(host);
                 }


### PR DESCRIPTION
When DockerInfrastructure.REMOVE_EMPTY_DOCKER_HOSTS is set to true and a container is removed a check will be performed to see if any containers are running on the host. If the host has no other containers it will also be removed. This will also remove the last host when the last container is removed. I would suggest that the last host should be kept even when it is empty.