### PR TITLE
update POM to skip testing for webUI (as there are no tests)

### DIFF
--- a/console/pom.xml
+++ b/console/pom.xml
@@ -59,6 +59,13 @@
                     </webResources>
                 </configuration>
             </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <skipTests>true</skipTests>
+              </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Maven gets confused (because of parent level test excludes) and fails with the error below unless modules without test have tests skipped.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.17:test (default-test) on project brooklyn-clocker-console: groups/excludedGroups require TestNG or JUnit48+ on project test classpath -> [Help 1]```

Should be reverted as soon as web UI will have tests added.
