### PR TITLE
Add simple initial Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+console
+docker
+patches
+examples/target/brooklyn-clocker-dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM gliderlabs/alpine:3.1
+
+RUN apk-install openjdk7-jre-base
+RUN apk-install bash
+
+ADD examples/target/brooklyn-clocker-dist.tar.gz .
+
+WORKDIR brooklyn-clocker
+
+VOLUME /root/.brooklyn
+
+EXPOSE 8081
+
+CMD bin/clocker.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ VOLUME /root/.brooklyn
 
 EXPOSE 8081
 
-CMD bin/clocker.sh
+ENTRYPOINT ["bin/clocker.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+clocker:
+  build: .
+  ports:
+   - "8081:8081"
+  volumes:
+   - "~/.brooklyn:/root/.brooklyn"


### PR DESCRIPTION
This Dockerfile allows building a clocker image once you build the dist tar.gz locally.

Once built you can just use `docker run -d -p 8082:8081 -v ~/.brooklyn:/root/.brooklyn clocker` to start clocker.

Few details:
* I assume we want a docker build (and push to docker-hub) as part of our build instead.
* The image is built on top of the super-light alpine distro hence the image size is relatively small. 
* brooklyn config has to be bind mounted to the clocker container to work

