### PR TITLE
initial Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ obj
 *.swp
 .DS_Store
 *.swp
+
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,6 @@ Vagrant.configure(2) do |config|
   # remote debug
   config.vm.network "forwarded_port", guest: 4000, host: 4000
 
-  config.vm.synced_folder "examples/target/brooklyn-clocker-dist/brooklyn-clocker", "/home/vagrant/clocker"
   config.vm.synced_folder "~/.brooklyn", "/home/vagrant/.brooklyn"
 
   config.vm.provision "shell", inline: <<-SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,23 @@
+Vagrant.configure(2) do |config|
+  config.vm.define "clocker"
+  config.vm.box = "trusty"
+  config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.name = "clocker"
+    vb.memory = "1024"
+  end
+
+  # brooklyn/clocker console
+  config.vm.network "forwarded_port", guest: 8081, host: 8081
+  # remote debug
+  config.vm.network "forwarded_port", guest: 4000, host: 4000
+
+  config.vm.synced_folder "examples/target/brooklyn-clocker-dist/brooklyn-clocker", "/home/vagrant/clocker"
+  config.vm.synced_folder "~/.brooklyn", "/home/vagrant/.brooklyn"
+
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo apt-get update
+    apt-get install -y openjdk-7-jdk
+  SHELL
+end


### PR DESCRIPTION
This is a basic Vagrantfile which sets up port forwarding and a synced directory for brooklyn config.

Clocker is not (yet) provisioned as a service within the VM. It can be started by `vagrant ssh` and manually invoking the clocker.sh script for now.