### PR TITLE
Upgrade weave to 1.0.0

### DIFF
--- a/docker/src/main/java/brooklyn/networking/sdn/weave/WeaveContainer.java
+++ b/docker/src/main/java/brooklyn/networking/sdn/weave/WeaveContainer.java
@@ -30,7 +30,7 @@ import brooklyn.util.flags.SetFromFlag;
 public interface WeaveContainer extends SdnAgent {
 
     @SetFromFlag("version")
-    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "0.11.2");
+    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "1.0.0");
 
     @SetFromFlag("weavePort")
     ConfigKey<Integer> WEAVE_PORT = ConfigKeys.newIntegerConfigKey("weave.port", "Weave port", 6783);

--- a/docker/src/main/java/brooklyn/networking/sdn/weave/WeaveContainer.java
+++ b/docker/src/main/java/brooklyn/networking/sdn/weave/WeaveContainer.java
@@ -30,7 +30,7 @@ import brooklyn.util.flags.SetFromFlag;
 public interface WeaveContainer extends SdnAgent {
 
     @SetFromFlag("version")
-    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "0.11.0");
+    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "0.11.2");
 
     @SetFromFlag("weavePort")
     ConfigKey<Integer> WEAVE_PORT = ConfigKeys.newIntegerConfigKey("weave.port", "Weave port", 6783);

--- a/docker/src/main/java/brooklyn/networking/sdn/weave/WeaveContainerSshDriver.java
+++ b/docker/src/main/java/brooklyn/networking/sdn/weave/WeaveContainerSshDriver.java
@@ -17,6 +17,7 @@ import brooklyn.entity.basic.Entities;
 import brooklyn.entity.basic.EntityLocal;
 import brooklyn.location.basic.SshMachineLocation;
 import brooklyn.networking.sdn.SdnAgent;
+import brooklyn.networking.sdn.SdnProvider;
 import brooklyn.util.collections.MutableMap;
 import brooklyn.util.net.Cidr;
 import brooklyn.util.os.Os;
@@ -67,7 +68,8 @@ public class WeaveContainerSshDriver extends AbstractSoftwareProcessSshDriver im
 
         newScript(MutableMap.of(USE_PID_FILE, false), LAUNCHING)
                 .updateTaskAndFailOnNonZeroResultCode()
-                .body.append(BashCommands.sudo(String.format("%s launch %s", getWeaveCommand(),
+                .body.append(BashCommands.sudo(String.format("%s launch -iprange %s %s", getWeaveCommand(),
+                        entity.config().get(SdnProvider.CONTAINER_NETWORK_CIDR),
                         Boolean.TRUE.equals(firstMember) ? "" : first.getAttribute(Attributes.SUBNET_ADDRESS))))
                 .execute();
     }

--- a/docker/src/main/java/brooklyn/networking/sdn/weave/WeaveNetwork.java
+++ b/docker/src/main/java/brooklyn/networking/sdn/weave/WeaveNetwork.java
@@ -30,7 +30,7 @@ import brooklyn.util.flags.SetFromFlag;
 public interface WeaveNetwork extends SdnProvider {
 
     @SetFromFlag("version")
-    ConfigKey<String> WEAVE_VERSION = ConfigKeys.newStringConfigKey("weave.version", "The Weave SDN version number", "0.11.0");
+    ConfigKey<String> WEAVE_VERSION = ConfigKeys.newStringConfigKey("weave.version", "The Weave SDN version number", "0.11.2");
 
     @SetFromFlag("weavePort")
     ConfigKey<Integer> WEAVE_PORT = WeaveContainer.WEAVE_PORT;

--- a/docker/src/main/java/brooklyn/networking/sdn/weave/WeaveNetwork.java
+++ b/docker/src/main/java/brooklyn/networking/sdn/weave/WeaveNetwork.java
@@ -30,7 +30,7 @@ import brooklyn.util.flags.SetFromFlag;
 public interface WeaveNetwork extends SdnProvider {
 
     @SetFromFlag("version")
-    ConfigKey<String> WEAVE_VERSION = ConfigKeys.newStringConfigKey("weave.version", "The Weave SDN version number", "0.11.2");
+    ConfigKey<String> WEAVE_VERSION = ConfigKeys.newStringConfigKey("weave.version", "The Weave SDN version number", "1.0.0");
 
     @SetFromFlag("weavePort")
     ConfigKey<Integer> WEAVE_PORT = WeaveContainer.WEAVE_PORT;

--- a/examples/src/main/assembly/files/blueprints/docker-cloud-weave.yaml
+++ b/examples/src/main/assembly/files/blueprints/docker-cloud-weave.yaml
@@ -38,7 +38,7 @@ services:
       $brooklyn:entitySpec:
         type: brooklyn.networking.sdn.weave.WeaveNetwork
         brooklyn.config:
-          weave.version: 0.11.2
+          weave.version: 1.0.0
     docker.host.spec:
       $brooklyn:entitySpec:
         type: brooklyn.entity.container.docker.DockerHost

--- a/examples/src/main/assembly/files/blueprints/docker-cloud-weave.yaml
+++ b/examples/src/main/assembly/files/blueprints/docker-cloud-weave.yaml
@@ -38,7 +38,7 @@ services:
       $brooklyn:entitySpec:
         type: brooklyn.networking.sdn.weave.WeaveNetwork
         brooklyn.config:
-          weave.version: 0.11.0
+          weave.version: 0.11.2
     docker.host.spec:
       $brooklyn:entitySpec:
         type: brooklyn.entity.container.docker.DockerHost

--- a/examples/src/main/java/brooklyn/clocker/WeaveDockerCloud.java
+++ b/examples/src/main/java/brooklyn/clocker/WeaveDockerCloud.java
@@ -53,7 +53,7 @@ public class WeaveDockerCloud extends AbstractApplication {
     public static final ConfigKey<String> DOCKER_VERSION = ConfigKeys.newConfigKeyWithDefault(DockerInfrastructure.DOCKER_VERSION, "1.6.2");
 
     @CatalogConfig(label="Weave Version", priority=90)
-    public static final ConfigKey<String> WEAVE_VERSION = ConfigKeys.newStringConfigKey("weave.version", "Weave SDN version", "0.11.2");
+    public static final ConfigKey<String> WEAVE_VERSION = ConfigKeys.newStringConfigKey("weave.version", "Weave SDN version", "1.0.0");
 
     @CatalogConfig(label="Location Name", priority=80)
     public static final ConfigKey<String> LOCATION_NAME = ConfigKeys.newConfigKeyWithDefault(DockerInfrastructure.LOCATION_NAME.getConfigKey(), "my-docker-cloud");

--- a/examples/src/main/java/brooklyn/clocker/WeaveDockerCloud.java
+++ b/examples/src/main/java/brooklyn/clocker/WeaveDockerCloud.java
@@ -53,7 +53,7 @@ public class WeaveDockerCloud extends AbstractApplication {
     public static final ConfigKey<String> DOCKER_VERSION = ConfigKeys.newConfigKeyWithDefault(DockerInfrastructure.DOCKER_VERSION, "1.6.2");
 
     @CatalogConfig(label="Weave Version", priority=90)
-    public static final ConfigKey<String> WEAVE_VERSION = ConfigKeys.newStringConfigKey("weave.version", "Weave SDN version", "0.11.0");
+    public static final ConfigKey<String> WEAVE_VERSION = ConfigKeys.newStringConfigKey("weave.version", "Weave SDN version", "0.11.2");
 
     @CatalogConfig(label="Location Name", priority=80)
     public static final ConfigKey<String> LOCATION_NAME = ConfigKeys.newConfigKeyWithDefault(DockerInfrastructure.LOCATION_NAME.getConfigKey(), "my-docker-cloud");


### PR DESCRIPTION
This PR upgrades clocker to use weave 0.11.2. As 1.0 was released in the meantime we're just going to upgrade to that.