### PR TITLE
Support docker exec (instead of SSH)

### DIFF
--- a/docker/src/main/java/brooklyn/entity/container/DockerAttributes.java
+++ b/docker/src/main/java/brooklyn/entity/container/DockerAttributes.java
@@ -75,6 +75,9 @@ public class DockerAttributes {
     public static final ConfigKey<Boolean> DOCKER_USE_HOST_DNS_NAME = ConfigKeys.newBooleanConfigKey(
             "docker.useHostDnsName", "Container uses same DNS hostname as Docker host", Boolean.TRUE);
 
+    public static final ConfigKey<Boolean> DOCKER_USE_EXEC = ConfigKeys.newBooleanConfigKey(
+            "docker.useExec", "Use docker exec instead of SSH", Boolean.TRUE);
+
     public static final ConfigKey<Integer> DOCKER_CPU_SHARES = ConfigKeys.newIntegerConfigKey(
             "docker.cpuShares", "Container CPU shares configuration");
 

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerContainer.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerContainer.java
@@ -82,6 +82,9 @@ public interface DockerContainer extends BasicStartable, HasNetworkAddresses, Ha
     @SetFromFlag("useHostDnsName")
     ConfigKey<Boolean> DOCKER_USE_HOST_DNS_NAME = DockerAttributes.DOCKER_USE_HOST_DNS_NAME;
 
+    @SetFromFlag("useExec")
+    ConfigKey<Boolean> DOCKER_USE_EXEC = DockerAttributes.DOCKER_USE_EXEC;
+
     @SetFromFlag("cpuShares")
     ConfigKey<Integer> DOCKER_CPU_SHARES = DockerAttributes.DOCKER_CPU_SHARES;
 

--- a/docker/src/main/java/brooklyn/location/docker/DockerContainerLocation.java
+++ b/docker/src/main/java/brooklyn/location/docker/DockerContainerLocation.java
@@ -26,6 +26,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -171,8 +172,9 @@ public class DockerContainerLocation extends SshMachineLocation implements Suppo
     @Override
     public int execScript(Map<String,?> props, String summaryForLogging, List<String> commands, Map<String,?> env) {
         if(getOwner().config().get(DockerContainer.DOCKER_USE_EXEC)) {
+            Map<String,?> nonPortProps = Maps.filterKeys(props, Predicates.not(Predicates.containsPattern("port")));
             SshMachineLocation host = getOwner().getDockerHost().getDynamicLocation().getMachine();
-            return host.execCommands(props, summaryForLogging, getExecScript(commands));
+            return host.execCommands(nonPortProps, summaryForLogging, getExecScript(commands));
         } else {
             Iterable<String> filtered = Iterables.filter(commands, DockerCallbacks.FILTER);
             for (String commandString : filtered) {
@@ -186,7 +188,8 @@ public class DockerContainerLocation extends SshMachineLocation implements Suppo
     public int execCommands(Map<String,?> props, String summaryForLogging, List<String> commands, Map<String,?> env) {
         if(getOwner().config().get(DockerContainer.DOCKER_USE_EXEC)) {
             SshMachineLocation host = getOwner().getDockerHost().getDynamicLocation().getMachine();
-            return host.execCommands(props, summaryForLogging, getExecCommands(commands));
+            Map<String,?> nonPortProps = Maps.filterKeys(props, Predicates.not(Predicates.containsPattern("port")));
+            return host.execCommands(nonPortProps, summaryForLogging, getExecCommands(commands));
         } else {
             Iterable<String> filtered = Iterables.filter(commands, DockerCallbacks.FILTER);
             for (String commandString : filtered) {

--- a/docker/src/main/java/brooklyn/location/docker/DockerContainerLocation.java
+++ b/docker/src/main/java/brooklyn/location/docker/DockerContainerLocation.java
@@ -21,6 +21,7 @@ import static java.lang.String.format;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -168,20 +169,39 @@ public class DockerContainerLocation extends SshMachineLocation implements Suppo
 
     @Override
     public int execScript(Map<String,?> props, String summaryForLogging, List<String> commands, Map<String,?> env) {
-        Iterable<String> filtered = Iterables.filter(commands, DockerCallbacks.FILTER);
-        for (String commandString : filtered) {
-            parseDockerCallback(commandString);
+        if(getOwner().config().get(DockerContainer.DOCKER_USE_EXEC)) {
+            SshMachineLocation host = getOwner().getDockerHost().getDynamicLocation().getMachine();
+            return host.execCommands(props, summaryForLogging, getExecCommands(commands));
+        } else {
+            Iterable<String> filtered = Iterables.filter(commands, DockerCallbacks.FILTER);
+            for (String commandString : filtered) {
+                parseDockerCallback(commandString);
+            }
+            return super.execScript(props, summaryForLogging, commands, env);
         }
-        return super.execScript(props, summaryForLogging, commands, env);
     }
 
     @Override
     public int execCommands(Map<String,?> props, String summaryForLogging, List<String> commands, Map<String,?> env) {
-        Iterable<String> filtered = Iterables.filter(commands, DockerCallbacks.FILTER);
-        for (String commandString : filtered) {
-            parseDockerCallback(commandString);
+        if(getOwner().config().get(DockerContainer.DOCKER_USE_EXEC)) {
+            SshMachineLocation host = getOwner().getDockerHost().getDynamicLocation().getMachine();
+            return host.execCommands(props, summaryForLogging, getExecCommands(commands));
+        } else {
+            Iterable<String> filtered = Iterables.filter(commands, DockerCallbacks.FILTER);
+            for (String commandString : filtered) {
+                parseDockerCallback(commandString);
+            }
+            return super.execCommands(props, summaryForLogging, commands, env);
         }
-        return super.execCommands(props, summaryForLogging, commands, env);
+    }
+
+    private List<String> getExecCommands(List<String> commands) {
+        List<String> result = new LinkedList<String>();
+        String prefix = "docker exec " + dockerContainer.getContainerId() + " ";
+        for(String command: commands) {
+            result.add(prefix + command);
+        }
+        return result;
     }
 
     private void parseDockerCallback(String commandString) {

--- a/docker/src/main/java/brooklyn/location/docker/DockerContainerLocation.java
+++ b/docker/src/main/java/brooklyn/location/docker/DockerContainerLocation.java
@@ -174,7 +174,7 @@ public class DockerContainerLocation extends SshMachineLocation implements Suppo
         if(getOwner().config().get(DockerContainer.DOCKER_USE_EXEC)) {
             Map<String,?> nonPortProps = Maps.filterKeys(props, Predicates.not(Predicates.containsPattern("port")));
             SshMachineLocation host = getOwner().getDockerHost().getDynamicLocation().getMachine();
-            return host.execCommands(nonPortProps, summaryForLogging, getExecScript(commands));
+            return host.execCommands(nonPortProps, summaryForLogging, getExecScript(commands, env));
         } else {
             Iterable<String> filtered = Iterables.filter(commands, DockerCallbacks.FILTER);
             for (String commandString : filtered) {
@@ -187,9 +187,10 @@ public class DockerContainerLocation extends SshMachineLocation implements Suppo
     @Override
     public int execCommands(Map<String,?> props, String summaryForLogging, List<String> commands, Map<String,?> env) {
         if(getOwner().config().get(DockerContainer.DOCKER_USE_EXEC)) {
+
             SshMachineLocation host = getOwner().getDockerHost().getDynamicLocation().getMachine();
             Map<String,?> nonPortProps = Maps.filterKeys(props, Predicates.not(Predicates.containsPattern("port")));
-            return host.execCommands(nonPortProps, summaryForLogging, getExecCommands(commands));
+            return host.execCommands(nonPortProps, summaryForLogging, getExecCommands(commands, env));
         } else {
             Iterable<String> filtered = Iterables.filter(commands, DockerCallbacks.FILTER);
             for (String commandString : filtered) {
@@ -199,16 +200,26 @@ public class DockerContainerLocation extends SshMachineLocation implements Suppo
         }
     }
 
-    private List<String> getExecScript(List<String> commands) {
+    private List<String> getExecScript(List<String> commands, Map<String,?> env) {
         String prefix = "docker exec " + dockerContainer.getContainerId() + " '";
-        return Collections.singletonList(prefix + Joiner.on(';').join(commands) + "'");
+        return Collections.singletonList(prefix + Joiner.on(';').join(
+                Iterables.concat(getEnvVarCommands(env), commands)) + "'");
     }
 
-    private List<String> getExecCommands(List<String> commands) {
+    private List<String> getExecCommands(List<String> commands, Map<String,?> env) {
         List<String> result = new LinkedList<String>();
+        result.addAll(getEnvVarCommands(env));
         String prefix = "docker exec " + dockerContainer.getContainerId() + " ";
         for(String command: commands) {
             result.add(prefix + command);
+        }
+        return result;
+    }
+
+    private List<String> getEnvVarCommands(Map<String,?> env) {
+        List<String> result = new LinkedList<String>();
+        for(Map.Entry<String, ?> envVar : env.entrySet()) {
+            result.add("export " + envVar.getKey() + "=" + envVar.getValue());
         }
         return result;
     }

--- a/docker/src/main/java/brooklyn/location/docker/DockerContainerLocation.java
+++ b/docker/src/main/java/brooklyn/location/docker/DockerContainerLocation.java
@@ -21,6 +21,7 @@ import static java.lang.String.format;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -171,7 +172,7 @@ public class DockerContainerLocation extends SshMachineLocation implements Suppo
     public int execScript(Map<String,?> props, String summaryForLogging, List<String> commands, Map<String,?> env) {
         if(getOwner().config().get(DockerContainer.DOCKER_USE_EXEC)) {
             SshMachineLocation host = getOwner().getDockerHost().getDynamicLocation().getMachine();
-            return host.execCommands(props, summaryForLogging, getExecCommands(commands));
+            return host.execCommands(props, summaryForLogging, getExecScript(commands));
         } else {
             Iterable<String> filtered = Iterables.filter(commands, DockerCallbacks.FILTER);
             for (String commandString : filtered) {
@@ -193,6 +194,11 @@ public class DockerContainerLocation extends SshMachineLocation implements Suppo
             }
             return super.execCommands(props, summaryForLogging, commands, env);
         }
+    }
+
+    private List<String> getExecScript(List<String> commands) {
+        String prefix = "docker exec " + dockerContainer.getContainerId() + " '";
+        return Collections.singletonList(prefix + Joiner.on(';').join(commands) + "'");
     }
 
     private List<String> getExecCommands(List<String> commands) {


### PR DESCRIPTION
This is still work in progress. It's a naive implementation for using docker exec instead of SSHing in to container to execute commands.

* need to rebase this on top of the latest master (with latest weave) then force push
* env vars are not handled properly
* there are a few places where DockerContainerLocation is still used as an SSH location as it implements that interface (e.g. MachineLifecycleEffectorTasks.resolveOnBoxDir)