### PR TITLE
Make sure brooklyn home is on the classpath

### DIFF
--- a/examples/src/main/assembly/scripts/brooklyn.sh
+++ b/examples/src/main/assembly/scripts/brooklyn.sh
@@ -35,7 +35,7 @@ if [ -z "${JAVA_OPTS}" ] ; then
 fi
 
 # set up the classpath
-INITIAL_CLASSPATH=${BROOKLYN_HOME}/conf:${BROOKLYN_HOME}/lib/patch/*:${BROOKLYN_HOME}/lib/brooklyn/*:${BROOKLYN_HOME}/lib/dropins/*
+INITIAL_CLASSPATH=${BROOKLYN_HOME}:${BROOKLYN_HOME}/conf:${BROOKLYN_HOME}/lib/patch/*:${BROOKLYN_HOME}/lib/brooklyn/*:${BROOKLYN_HOME}/lib/dropins/*
 # specify additional CP args in BROOKLYN_CLASSPATH
 if [ ! -z "${BROOKLYN_CLASSPATH}" ]; then
     INITIAL_CLASSPATH=${BROOKLYN_CLASSPATH}:${INITIAL_CLASSPATH}


### PR DESCRIPTION
Clocker relies on the /conf directory being on the classpath as it loads certs using a path including `conf/...`.

Somehow the directory where the script is executed from is always on the classpath but we can't rely on that if we want to run the script from any other directory the the distribution directory containing conf.

The distribution directory is already resolved correctly by the startups scripts so we can just add that to the classpath as well to make sure certificates are found even if we run clocker.sh from a different directory.
