### PR TITLE
remove jdk from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 language: java
-jdk:
-- openjdk7
 script: mvn clean install
 before_deploy: "mkdir artifacts && mv examples/target/brooklyn-clocker-dist.tar.gz artifacts/brooklyn-clocker-${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT}-dist.tar.gz"
 deploy:


### PR DESCRIPTION
As travis uses for [oracle jdk7](http://docs.travis-ci.com/user/languages/java/#Overview) by default for `language: java` projects, it can be removed.