### PR TITLE
Add alpine support when layering sshd on top

### DIFF
--- a/docker/src/main/resources/brooklyn/entity/container/docker/SshdDockerfile
+++ b/docker/src/main/resources/brooklyn/entity/container/docker/SshdDockerfile
@@ -28,12 +28,16 @@ RUN type locale-gen ; if [ "$?" -eq "0" ] ; then locale-gen en_US.UTF-8 ; fi
 RUN echo 'root:${entity.password}' | chpasswd
 
 # install sshd
-RUN type apt-get ; \
-  if [ "$?" -eq "0" ] ; then \
+RUN if [ -x "$(which apt-get)" ] ; then \
     apt-get update ; \
     apt-get install -y openssh-server ; \
-  else \
+  elif [ -x "$(which yum)" ] ; then \
     yum -y install openssh-server ; \
+  elif [ -x "$(which apk-install)" ] ; then \
+    apk-install openssh ; \
+    ssh-keygen -q -N "" -t dsa -f /etc/ssh/ssh_host_dsa_key ; \
+    ssh-keygen -q -N "" -t rsa -f /etc/ssh/ssh_host_rsa_key ; \
+    sed -i "s/UsePrivilegeSeparation.*/UsePrivilegeSeparation no/g" /etc/ssh/sshd_config ; \
   fi ; \
   mkdir /var/run/sshd ; \
   chmod 600 /var/run/sshd ;
@@ -43,7 +47,7 @@ RUN sed -i.bk 's/PermitRootLogin.*$/PermitRootLogin yes/g' /etc/ssh/sshd_config 
   echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config
 
 # SSH login fix. Otherwise user is kicked off after login
-RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd || true
 
 EXPOSE 22
 


### PR DESCRIPTION
This change makes it possible to layer sshd on top of an alpine image.

e.g https://github.com/csabapalfi/hello-alpine-node can now be deployed with clocker.

I tested locally and using the SshdDockerfile results in an SSHable alpine image.
