### PR TITLE
Added check that the SDN provider is not null

### DIFF
--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerHostImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerHostImpl.java
@@ -313,9 +313,8 @@ public class DockerHostImpl extends MachineEntityImpl implements DockerHost {
                 if (vlanId == null) {
                     // If a previous host has been configured, look up the VLAN id
                     int count = sensors().get(DOCKER_INFRASTRUCTURE).sensors().get(DockerInfrastructure.DOCKER_HOST_COUNT);
-                    if (count > 1 && !sensors().get(DynamicCluster.FIRST_MEMBER)) {
-                        Task<Integer> lookup = DependentConfiguration.attributeWhenReady(sensors().get(DOCKER_INFRASTRUCTURE)
-                                .sensors().get(DockerInfrastructure.SDN_PROVIDER), SdnProvider.VLAN_ID);
+                    if (count > 1 && !sensors().get(DynamicCluster.FIRST_MEMBER) && sdnProviderAttribute != null) {
+                        Task<Integer> lookup = DependentConfiguration.attributeWhenReady(sdnProviderAttribute, SdnProvider.VLAN_ID);
                         vlanId = DynamicTasks.submit(lookup, this).getUnchecked();
                     }
                 }


### PR DESCRIPTION
I found a null pointer exception when using Softlayer, no SDN provider and more than one host. After the first host it attempts to lookup the VLAN ID from the SDN provider. The attributeWhenReady method throws a null pointer exception when the entity is null.

Added that the SDN provider is not null before attempting to lookup the VLAN ID.