### PR TITLE
Fix issue 173- Docker containers not cleaning up port bindings

### DIFF
--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerImpl.java
@@ -481,22 +481,40 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
     }
 
     public void configurePortBindings(DockerHost host, Entity entity) {
-        Map<Integer, Integer> bindings = entity.sensors().get(DockerAttributes.DOCKER_CONTAINER_PORT_BINDINGS);
-        if (bindings.size() > 0) {
-            Collection<IpPermission> permissions = MutableList.of();
-            for (Integer hostPort : bindings.keySet()) {
-                IpPermission portAccess = IpPermission.builder()
-                        .ipProtocol(IpProtocol.TCP)
-                        .fromPort(hostPort)
-                        .toPort(hostPort)
-                        .cidrBlock(Cidr.UNIVERSAL.toString())
-                        .build();
-                permissions.add(portAccess);
-            }
-            LOG.debug("Adding security group entries for forwarded ports on {}: {}", entity, Iterables.toString(bindings.keySet()));
-            host.addIpPermissions(permissions);
+        Collection<IpPermission> ipPermissions = getIpPermissions(entity);
+        if (ipPermissions.size() > 0) {
+            LOG.debug("Adding security group entries for forwarded ports on {}: {}", entity, Iterables.toString(ipPermissions));
+            host.addIpPermissions(ipPermissions);
         }
     }
+
+    public void removePortBindings(DockerHost host, Entity entity) {
+        Collection<IpPermission> ipPermissions = getIpPermissions(entity);
+        if (ipPermissions.size() > 0) {
+            LOG.debug("Removing security group entries for forwarded ports on {}: {}", entity, Iterables.toString(ipPermissions));
+            host.removeIpPermissions(ipPermissions);
+        }
+    }
+
+    public Collection<IpPermission> getIpPermissions(Entity entity) {
+        Map<Integer, Integer> bindings = entity.sensors().get(DockerAttributes.DOCKER_CONTAINER_PORT_BINDINGS);
+        if (bindings.size() == 0) {
+            return ImmutableList.<IpPermission>of();
+        }
+
+        Collection<IpPermission> permissions = MutableList.of();
+        for (Integer hostPort : bindings.keySet()) {
+            IpPermission portAccess = IpPermission.builder()
+                    .ipProtocol(IpProtocol.TCP)
+                    .fromPort(hostPort)
+                    .toPort(hostPort)
+                    .cidrBlock(Cidr.UNIVERSAL.toString())
+                    .build();
+            permissions.add(portAccess);
+        }
+        return permissions;
+    }
+
 
     /**
      * Create a new {@link DockerContainerLocation} wrapping a machine from the host's {@link JcloudsLocation}.
@@ -696,6 +714,8 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
         ServiceStateLogic.setExpectedState(this, Lifecycle.STOPPING);
 
         disconnectSensors();
+
+        removePortBindings(getDockerHost(), getRunningEntity());
 
         // Stop and remove the Docker container running on the host
         shutDown();

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerHost.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerHost.java
@@ -181,6 +181,7 @@ public interface DockerHost extends MachineEntity, Resizable, HasShortName, Loca
 
     void configureSecurityGroups();
     void addIpPermissions(Collection<IpPermission> permissions);
+    void removeIpPermissions(Collection<IpPermission> permissions);
 
     MethodEffector<String> BUILD_IMAGE = new MethodEffector<String>(DockerHost.class, "buildImage");
     MethodEffector<String> RUN_DOCKER_COMMAND = new MethodEffector<String>(DockerHost.class, "runDockerCommand");

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerHostImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerHostImpl.java
@@ -528,13 +528,35 @@ public class DockerHostImpl extends MachineEntityImpl implements DockerHost {
         addIpPermissions(permissions);
     }
 
+
+    @Override
+    public void removeIpPermissions(Collection<IpPermission> permissions) {
+        Location location = getDriver().getLocation();
+        String securityGroup = config().get(DockerInfrastructure.SECURITY_GROUP);
+        if (Strings.isBlank(securityGroup)) {
+            if (!(location instanceof JcloudsSshMachineLocation)) {
+                LOG.info("{} not running in a JcloudsSshMachineLocation, not removing ip permissions", this);
+                return;
+            }
+            // TODO check GCE compatibility?
+            JcloudsMachineLocation machine = (JcloudsMachineLocation) location;
+            JcloudsLocationSecurityGroupCustomizer customizer = JcloudsLocationSecurityGroupCustomizer.getInstance(getApplicationId());
+
+            // Serialize access across the whole infrastructure as the security groups are a shared resource
+            synchronized (getInfrastructure().getInfrastructureMutex()) {
+                LOG.debug("Removing permissions from security groups {}: {}", machine, permissions);
+                customizer.removePermissionsFromLocation(machine, permissions);
+            }
+        }
+    }
+
     @Override
     public void addIpPermissions(Collection<IpPermission> permissions) {
         Location location = getDriver().getLocation();
         String securityGroup = config().get(DockerInfrastructure.SECURITY_GROUP);
         if (Strings.isBlank(securityGroup)) {
             if (!(location instanceof JcloudsSshMachineLocation)) {
-                LOG.info("{} not running in a JcloudsSshMachineLocation, not configuring extra security groups", this);
+                LOG.info("{} not running in a JcloudsSshMachineLocation, not adding ip permissions", this);
                 return;
             }
             // TODO check GCE compatibility?


### PR DESCRIPTION
Previously, on shutdown, a docker container would not remove any security group IP/Port customisations that had been made. This would mean deploying, undeploying and then redeploying an application would sometimes fail as the customisation had already been made. This was also a security risk. This has now been fixed, and a docker container will clean up on shutdown any customisations that it makes.

This fixes issue [173](https://github.com/brooklyncentral/clocker/issues/173).