### PR TITLE
Install CA root certificates in the JRE

### DIFF
--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -19,11 +19,17 @@ MAINTAINER andrew.kennedy@cloudsoft.io
 LABEL version="1.1.0-SNAPSHOT"
 
 RUN apk-install openjdk7-jre-base ; \
+    apk-install openjdk7-jre-lib ; \
     apk-install bash ; \
     apk-install wget
 
+COPY imp.sh /tmp/imp.sh
+
+RUN bash /tmp/imp.sh /usr/lib/jvm/java-1.7-openjdk/jre/lib/security/cacerts ; \
+    rm -f /tmp/imp.sh
+
 # CLOCKER_VERSION_BELOW
-RUN wget https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots\&g=io.brooklyn.clocker\&a=brooklyn-clocker-dist\&v=1.1.0-SNAPSHOT\&c=dist\&e=tar.gz -O /brooklyn-clocker-dist.tar.gz ; \
+RUN wget --no-check-certificate https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots\&g=io.brooklyn.clocker\&a=brooklyn-clocker-dist\&v=1.1.0-SNAPSHOT\&c=dist\&e=tar.gz -O /brooklyn-clocker-dist.tar.gz ; \
     tar zxf brooklyn-clocker-dist.tar.gz ; \
     rm -f brooklyn-clocker-dist.tar.gz
 

--- a/dist/imp.sh
+++ b/dist/imp.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Generate CA Certs
+# adapted from the OBuildFactory project code at
+# https://github.com/hgomez/obuildfactory/blob/master/openjdk7/macosx/build.sh
+# (Apache License 2.0)
+#
+function cacerts_gen()
+{
+  local DESTCERTS=$1
+  local TMPCERTSDIR=`mktemp -d certs-XXXXXX`
+
+  pushd $TMPCERTSDIR > /dev/null
+  wget http://curl.haxx.se/ca/cacert.pem
+  cat cacert.pem | awk '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/{ print $0; }' > cacert-clean.pem
+  rm -f cacerts cert_*
+  awk '/-----BEGIN CERTIFICATE-----/{x=++i;}{print > "cert_"x;}' cacert-clean.pem
+
+  for CERT_FILE in cert_*; do
+    ALIAS=$(basename ${CERT_FILE})
+    keytool -noprompt -trustcacerts -import -alias ${ALIAS} -keystore cacerts -storepass 'changeit' -file ${CERT_FILE} || :
+    rm -f $CERT_FILE
+  done
+
+  rm -f cacert.pem cacert-clean.pem
+  cp cacerts $DESTCERTS
+
+  popd > /dev/null
+  rm -rf $TMPCERTSDIR
+}
+
+cacerts_gen $1


### PR DESCRIPTION
- using latest Mozilla-provided certs from
  http://curl.haxx.se/ca/cacert.pem

The lack of root certificates causes, e.g.,  a `java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty` using this sample blueprint: 
```
location: . . .

services:
- type: org.apache.brooklyn.entity.database.mysql.MySqlNode
  id: db
  name: My DB
  brooklyn.config:
    creationScriptUrl: https://bit.ly/brooklyn-visitors-creation-script
``` 

just because of the https URL