### PR TITLE
Update Weave version to 1.1.2 and set environment variable

### DIFF
--- a/clocker.bom
+++ b/clocker.bom
@@ -112,7 +112,7 @@ brooklyn.catalog:
     item:
       type: brooklyn.networking.sdn.weave.WeaveNetwork
       brooklyn.config:
-        weave.version: 1.1.0
+        weave.version: 1.1.2
         sdn.agent.spec:
           $brooklyn:entitySpec:
             type: weave-router

--- a/dist/src/main/assembly/conf/brooklyn/default.catalog.bom
+++ b/dist/src/main/assembly/conf/brooklyn/default.catalog.bom
@@ -102,7 +102,7 @@ brooklyn.catalog:
     item:
       type: brooklyn.networking.sdn.weave.WeaveNetwork
       brooklyn.config:
-        weave.version: 1.1.0
+        weave.version: 1.1.2
         sdn.agent.spec:
           $brooklyn:entitySpec:
             type: weave-router

--- a/docker/src/main/java/brooklyn/networking/sdn/weave/WeaveContainer.java
+++ b/docker/src/main/java/brooklyn/networking/sdn/weave/WeaveContainer.java
@@ -31,7 +31,7 @@ import brooklyn.networking.sdn.SdnAgent;
 public interface WeaveContainer extends SdnAgent {
 
     @SetFromFlag("version")
-    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "1.1.0");
+    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "1.1.2");
 
     @SetFromFlag("weavePort")
     ConfigKey<Integer> WEAVE_PORT = ConfigKeys.newIntegerConfigKey("weave.port", "Weave port", 6783);

--- a/docker/src/main/java/brooklyn/networking/sdn/weave/WeaveContainerSshDriver.java
+++ b/docker/src/main/java/brooklyn/networking/sdn/weave/WeaveContainerSshDriver.java
@@ -19,6 +19,7 @@ import static org.apache.brooklyn.util.ssh.BashCommands.chain;
 
 import java.net.InetAddress;
 import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -146,6 +147,14 @@ public class WeaveContainerSshDriver extends AbstractSoftwareProcessSshDriver im
         } finally {
             Tasks.resetBlockingDetails();
         }
+    }
+
+    @Override
+    public Map<String, String> getShellEnvironment() {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.<String, String> builder()
+                .putAll(super.getShellEnvironment())
+                .put("VERSION", entity.config().get(WeaveContainer.SUGGESTED_VERSION));
+        return builder.build();
     }
 
 }


### PR DESCRIPTION
Fixes issue where Weave uses the wrong version of the router image from Docker hub. Note that the variable name changhes to `WEAVE_VERSION` in version 1.2.0  and above.