### PR TITLE
Unique marathon task IDs & misc

### DIFF
--- a/mesos/src/main/java/brooklyn/entity/mesos/task/marathon/MarathonTaskImpl.java
+++ b/mesos/src/main/java/brooklyn/entity/mesos/task/marathon/MarathonTaskImpl.java
@@ -522,8 +522,13 @@ public class MarathonTaskImpl extends MesosTaskImpl implements MarathonTask {
         if (!HttpTool.isStatusCodeHealthy(response.getResponseCode())) {
             return Optional.absent();
         } else {
-            LOG.debug("Application JSON: {}", response.getContentAsString());
-            return Optional.of(HttpValueFunctions.jsonContents().apply(response));
+            JsonElement app = HttpValueFunctions.jsonContents().apply(response);
+            if (app.isJsonNull()) {
+                return Optional.absent();
+            } else {
+                LOG.debug("Application JSON: {}", response.getContentAsString());
+                return Optional.of(app);
+            }
         }
     }
 

--- a/mesos/src/main/java/brooklyn/location/mesos/framework/marathon/MarathonLocation.java
+++ b/mesos/src/main/java/brooklyn/location/mesos/framework/marathon/MarathonLocation.java
@@ -125,7 +125,7 @@ public class MarathonLocation extends MesosFrameworkLocation implements MachineP
             }
 
             // Start a new task with flags from entity
-            String name = Optional.fromNullable(entity.config().get(BrooklynCampConstants.PLAN_ID)).or(entity.getId());
+            String name = getTaskName(entity);
             Map<Object, Object> taskFlags = MutableMap.builder()
                     .putAll(flags)
                     .put("entity", entity)
@@ -154,6 +154,15 @@ public class MarathonLocation extends MesosFrameworkLocation implements MachineP
             return marathonTask.getDynamicLocation();
         } finally {
             lock.readLock().unlock();
+        }
+    }
+
+    private String getTaskName(Entity entity) {
+        String planId = entity.config().get(BrooklynCampConstants.PLAN_ID);
+        if (planId != null) {
+            return planId + "/" + entity.getId();
+        } else {
+            return entity.getId();
         }
     }
 


### PR DESCRIPTION
Marathon task IDs should be unique even if a plan ID is passed - so that multiple deployments from the same catalog item can be created.
Also treat a JsonNull as null - found during testing.