### PR TITLE
Add ability to set container environment variables to Microservice* apps

### DIFF
--- a/dist/src/main/java/brooklyn/clocker/example/Microservice.java
+++ b/dist/src/main/java/brooklyn/clocker/example/Microservice.java
@@ -15,6 +15,7 @@
  */
 package brooklyn.clocker.example;
 
+import brooklyn.entity.container.docker.DockerContainer;
 import org.apache.brooklyn.api.catalog.CatalogConfig;
 import org.apache.brooklyn.api.entity.Application;
 import org.apache.brooklyn.api.entity.ImplementedBy;
@@ -23,6 +24,8 @@ import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 
 import brooklyn.entity.container.docker.application.VanillaDockerApplication;
+
+import java.util.Map;
 
 /**
  * Brooklyn managed {@link VanillaDockerApplication}.
@@ -40,6 +43,9 @@ public interface Microservice extends Application {
 
     @CatalogConfig(label = "Direct Ports", priority = 70)
     ConfigKey<String> DIRECT_PORTS = ConfigKeys.newStringConfigKey("docker.directPorts", "Comma separated list of ports to open directly on the host");
+
+    @CatalogConfig(label = "Container Environment Variables", priority = 70)
+    ConfigKey<Map<String, Object>> DOCKER_CONTAINER_ENVIRONMENT = DockerContainer.DOCKER_CONTAINER_ENVIRONMENT.getConfigKey();
 
     ConfigKey<String> ONBOX_BASE_DIR = ConfigKeys.newConfigKeyWithDefault(BrooklynConfigKeys.ONBOX_BASE_DIR, "/tmp/brooklyn");
     ConfigKey<Boolean> SKIP_ON_BOX_BASE_DIR_RESOLUTION = ConfigKeys.newConfigKeyWithDefault(BrooklynConfigKeys.SKIP_ON_BOX_BASE_DIR_RESOLUTION, Boolean.TRUE);

--- a/dist/src/main/java/brooklyn/clocker/example/MicroserviceImageImpl.java
+++ b/dist/src/main/java/brooklyn/clocker/example/MicroserviceImageImpl.java
@@ -29,9 +29,10 @@ import org.apache.brooklyn.core.entity.Entities;
 import brooklyn.entity.container.docker.DockerInfrastructure;
 import brooklyn.entity.container.docker.application.VanillaDockerApplication;
 import brooklyn.location.docker.DockerLocation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MicroserviceImageImpl extends AbstractApplication implements MicroserviceImage {
-
     protected VanillaDockerApplication vanillaDockerApplication = null;
 
     @Override
@@ -41,7 +42,8 @@ public class MicroserviceImageImpl extends AbstractApplication implements Micros
                 .configure("imageName", config().get(IMAGE_NAME))
                 .configure("imageTag", config().get(IMAGE_TAG))
                 .configure("openPorts", config().get(OPEN_PORTS))
-                .configure("directPorts", config().get(DIRECT_PORTS)));
+                .configure("directPorts", config().get(DIRECT_PORTS))
+                .configure("env", config().get(DOCKER_CONTAINER_ENVIRONMENT)));
     }
 
     @Override


### PR DESCRIPTION
Tested on Softlayer with:

```
name: RabbitMQ
location: SoftlayerAMS01
services:
  - type: "brooklyn.clocker.example.MicroserviceImage:1.1.0-SNAPSHOT"
    brooklyn.config:
      docker.containerName: rabbitmq-with-console
      docker.image.name: rabbitmq
      docker.image.tag: 3-management
      docker.openPorts: "4369,5671,5672,25672,15672"
      docker.directPorts: "4369,5671,5672,25672,15672"
      docker.container.environment:
        RABBITMQ_DEFAULT_USER: "admin"
        RABBITMQ_DEFAULT_PASS: "admin"
```