### PR TITLE
Fix container names

### DIFF
--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerImpl.java
@@ -278,7 +278,7 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
         Boolean useHostDns = Objects.firstNonNull(entity.config().get(DOCKER_USE_HOST_DNS_NAME), Boolean.FALSE);
         String hostname = getDockerHost().sensors().get(Attributes.HOSTNAME);
         String address = getDockerHost().sensors().get(Attributes.ADDRESS);
-        String container = getContainerName(entity).or(getDockerContainerName());
+        String container = getContainerName(entity).or(Optional.fromNullable(getDockerContainerName())).get();
         String name = (!useHostDns || hostname.equalsIgnoreCase(address)) ? container : hostname;
         options.hostname(name);
         options.nodeNames(ImmutableList.of(name));


### PR DESCRIPTION
Recreated this PR, as it wouldn't let me re-open the original.
Whilst we now have config with a default to make the scenario unlikely, the code will still fall over when "getContainerName(entity)" returns a value but "getDockerContainerName()" does not. I think the code should only throw an exception when both are null, hence this change.