### PR TITLE
Fixed ssh key issue

### DIFF
--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerImpl.java
@@ -560,8 +560,6 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
                 .put(LocationConfigKeys.USER, "root")
                 .put(LocationConfigKeys.PASSWORD, config().get(DOCKER_PASSWORD))
                 .put(SshTool.PROP_PASSWORD, config().get(DOCKER_PASSWORD))
-                .put(LocationConfigKeys.PRIVATE_KEY_DATA, null)
-                .put(LocationConfigKeys.PRIVATE_KEY_FILE, null)
                 .put(CloudLocationConfig.WAIT_FOR_SSHABLE, false)
                 .put(JcloudsLocationConfig.INBOUND_PORTS, options.getInboundPorts())
                 .put(JcloudsLocation.USE_PORT_FORWARDING, true)


### PR DESCRIPTION
Previously, we were nulling out Brooklyn configuration about the location of the private key file.
This meant that a user must have a passwordless SSH key in the default location ~/.ssh/id_rsa
This change removes the nulling out, such that users can specify the SSH key.