### PR TITLE
Add portBinding to Microservice (Image/Dockerfile).

### DIFF
--- a/dist/src/main/java/brooklyn/clocker/example/Microservice.java
+++ b/dist/src/main/java/brooklyn/clocker/example/Microservice.java
@@ -15,6 +15,7 @@
  */
 package brooklyn.clocker.example;
 
+import brooklyn.entity.container.DockerAttributes;
 import brooklyn.entity.container.docker.DockerContainer;
 import org.apache.brooklyn.api.catalog.CatalogConfig;
 import org.apache.brooklyn.api.entity.Application;
@@ -43,6 +44,9 @@ public interface Microservice extends Application {
 
     @CatalogConfig(label = "Direct Ports", priority = 70)
     ConfigKey<String> DIRECT_PORTS = ConfigKeys.newStringConfigKey("docker.directPorts", "Comma separated list of ports to open directly on the host");
+
+    @CatalogConfig(label = "Mapped Ports", priority = 70)
+    ConfigKey<Map<Integer, Integer>> DOCKER_PORT_BINDINGS = DockerAttributes.DOCKER_PORT_BINDINGS;
 
     @CatalogConfig(label = "Container Environment Variables", priority = 70)
     ConfigKey<Map<String, Object>> DOCKER_CONTAINER_ENVIRONMENT = DockerContainer.DOCKER_CONTAINER_ENVIRONMENT.getConfigKey();

--- a/dist/src/main/java/brooklyn/clocker/example/MicroserviceDockerfileImpl.java
+++ b/dist/src/main/java/brooklyn/clocker/example/MicroserviceDockerfileImpl.java
@@ -40,7 +40,9 @@ public class MicroserviceDockerfileImpl extends AbstractApplication implements M
                 .configure("containerName", config().get(CONTAINER_NAME))
                 .configure("dockerfileUrl", config().get(DOCKERFILE_URL))
                 .configure("openPorts", config().get(OPEN_PORTS))
-                .configure("directPorts", config().get(DIRECT_PORTS)));
+                .configure("directPorts", config().get(DIRECT_PORTS))
+                .configure("env", config().get(DOCKER_CONTAINER_ENVIRONMENT))
+                .configure("portBindings", config().get(DOCKER_PORT_BINDINGS)));
     }
 
     @Override

--- a/dist/src/main/java/brooklyn/clocker/example/MicroserviceImageImpl.java
+++ b/dist/src/main/java/brooklyn/clocker/example/MicroserviceImageImpl.java
@@ -43,7 +43,8 @@ public class MicroserviceImageImpl extends AbstractApplication implements Micros
                 .configure("imageTag", config().get(IMAGE_TAG))
                 .configure("openPorts", config().get(OPEN_PORTS))
                 .configure("directPorts", config().get(DIRECT_PORTS))
-                .configure("env", config().get(DOCKER_CONTAINER_ENVIRONMENT)));
+                .configure("env", config().get(DOCKER_CONTAINER_ENVIRONMENT))
+                .configure("portBindings", config().get(DOCKER_PORT_BINDINGS)));
     }
 
     @Override


### PR DESCRIPTION
Tested with:
```
name: RabbitMQ
location: softlayer-ams01
services:
  - type: brooklyn.clocker.example.MicroserviceImage:1.1.0-SNAPSHOT
    brooklyn.config:
      docker.containerName: rabbitmq-with-console
      docker.image.name: rabbitmq
      docker.image.tag: 3-management
      docker.container.portBindings:
        4369: 4369
        5671: 5671
        5672: 5672
        25672: 25672
        80: 15672
      docker.container.environment:
        RABBITMQ_DEFAULT_USER: admin
        RABBITMQ_DEFAULT_PASS: secret 
        HOSTNAME: dockerhost
```
And the same via Dockerfile:
```
name: RabbitMQDockerfile
location: softlayer-ams01
services:
  - type: brooklyn.clocker.example.MicroserviceDockerfile:1.1.0-SNAPSHOT
    brooklyn.config:
      docker.containerName: rabbitmq-with-console-from-dockerfile
      docker.dockerfile.url: https://raw.githubusercontent.com/docker-library/rabbitmq/60e5665854131f7fcb9ab0285d7d52ac932efb43/management/Dockerfile
      docker.container.portBindings:
        4369: 4369
        5671: 5671
        5672: 5672
        25672: 25672
        8080: 15672
      docker.container.environment:
        RABBITMQ_DEFAULT_USER: admin2
        RABBITMQ_DEFAULT_PASS: secret2
        HOSTNAME: dockerhost2
```
