### PR TITLE
Added volume and entrypoint config to microservices

### DIFF
--- a/dist/src/main/java/brooklyn/clocker/example/Microservice.java
+++ b/dist/src/main/java/brooklyn/clocker/example/Microservice.java
@@ -15,17 +15,20 @@
  */
 package brooklyn.clocker.example;
 
-import brooklyn.entity.container.docker.DockerContainer;
+import java.util.Map;
+
 import org.apache.brooklyn.api.catalog.CatalogConfig;
 import org.apache.brooklyn.api.entity.Application;
 import org.apache.brooklyn.api.entity.ImplementedBy;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
 
+import brooklyn.entity.container.DockerAttributes;
+import brooklyn.entity.container.docker.DockerContainer;
+import brooklyn.entity.container.docker.DockerHost;
 import brooklyn.entity.container.docker.application.VanillaDockerApplication;
-
-import java.util.Map;
 
 /**
  * Brooklyn managed {@link VanillaDockerApplication}.
@@ -36,16 +39,25 @@ public interface Microservice extends Application {
     String DOCKER_LOCATION_PREFIX = "docker-";
 
     @CatalogConfig(label = "Container Name", priority = 90)
-    ConfigKey<String> CONTAINER_NAME = ConfigKeys.newStringConfigKey("docker.containerName", "Container name", "service");
+    @SetFromFlag("containerName")
+    ConfigKey<String> CONTAINER_NAME = DockerContainer.DOCKER_CONTAINER_NAME.getConfigKey();
 
     @CatalogConfig(label = "Open Ports", priority = 70)
+    @SetFromFlag("openPorts")
     ConfigKey<String> OPEN_PORTS = ConfigKeys.newStringConfigKey("docker.openPorts", "Comma separated list of ports the application uses");
 
     @CatalogConfig(label = "Direct Ports", priority = 70)
+    @SetFromFlag("directPorts")
     ConfigKey<String> DIRECT_PORTS = ConfigKeys.newStringConfigKey("docker.directPorts", "Comma separated list of ports to open directly on the host");
 
-    @CatalogConfig(label = "Container Environment Variables", priority = 70)
+    @SetFromFlag("portBindings")
+    ConfigKey<Map<Integer, Integer>> PORT_BINDINGS = DockerAttributes.DOCKER_PORT_BINDINGS;
+
+    @SetFromFlag("env")
     ConfigKey<Map<String, Object>> DOCKER_CONTAINER_ENVIRONMENT = DockerContainer.DOCKER_CONTAINER_ENVIRONMENT.getConfigKey();
+
+    @SetFromFlag("volumeMappings")
+    ConfigKey<Map<String, String>> DOCKER_HOST_VOLUME_MAPPING = DockerHost.DOCKER_HOST_VOLUME_MAPPING.getConfigKey();
 
     ConfigKey<String> ONBOX_BASE_DIR = ConfigKeys.newConfigKeyWithDefault(BrooklynConfigKeys.ONBOX_BASE_DIR, "/tmp/brooklyn");
     ConfigKey<Boolean> SKIP_ON_BOX_BASE_DIR_RESOLUTION = ConfigKeys.newConfigKeyWithDefault(BrooklynConfigKeys.SKIP_ON_BOX_BASE_DIR_RESOLUTION, Boolean.TRUE);

--- a/dist/src/main/java/brooklyn/clocker/example/MicroserviceDockerfile.java
+++ b/dist/src/main/java/brooklyn/clocker/example/MicroserviceDockerfile.java
@@ -19,6 +19,7 @@ import org.apache.brooklyn.api.catalog.Catalog;
 import org.apache.brooklyn.api.catalog.CatalogConfig;
 import org.apache.brooklyn.api.entity.ImplementedBy;
 import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
 
 import brooklyn.entity.container.docker.application.VanillaDockerApplication;
 
@@ -32,6 +33,7 @@ import brooklyn.entity.container.docker.application.VanillaDockerApplication;
 public interface MicroserviceDockerfile extends Microservice {
 
     @CatalogConfig(label = "Dockerfile URL", priority = 80)
+    @SetFromFlag("dockerfileUrl")
     ConfigKey<String> DOCKERFILE_URL = VanillaDockerApplication.DOCKERFILE_URL;
 
 }

--- a/dist/src/main/java/brooklyn/clocker/example/MicroserviceDockerfileImpl.java
+++ b/dist/src/main/java/brooklyn/clocker/example/MicroserviceDockerfileImpl.java
@@ -40,7 +40,10 @@ public class MicroserviceDockerfileImpl extends AbstractApplication implements M
                 .configure("containerName", config().get(CONTAINER_NAME))
                 .configure("dockerfileUrl", config().get(DOCKERFILE_URL))
                 .configure("openPorts", config().get(OPEN_PORTS))
-                .configure("directPorts", config().get(DIRECT_PORTS)));
+                .configure("directPorts", config().get(DIRECT_PORTS))
+                .configure("portBindings", config().get(PORT_BINDINGS))
+                .configure("env", config().get(DOCKER_CONTAINER_ENVIRONMENT))
+                .configure("volumeMappings", config().get(DOCKER_HOST_VOLUME_MAPPING)));
     }
 
     @Override

--- a/dist/src/main/java/brooklyn/clocker/example/MicroserviceImage.java
+++ b/dist/src/main/java/brooklyn/clocker/example/MicroserviceImage.java
@@ -15,10 +15,13 @@
  */
 package brooklyn.clocker.example;
 
+import java.util.List;
+
 import org.apache.brooklyn.api.catalog.Catalog;
 import org.apache.brooklyn.api.catalog.CatalogConfig;
 import org.apache.brooklyn.api.entity.ImplementedBy;
 import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
 
 import brooklyn.entity.container.docker.application.VanillaDockerApplication;
 
@@ -32,9 +35,14 @@ import brooklyn.entity.container.docker.application.VanillaDockerApplication;
 public interface MicroserviceImage extends Microservice {
 
     @CatalogConfig(label = "Image Name", priority = 80)
+    @SetFromFlag("imageName")
     ConfigKey<String> IMAGE_NAME = VanillaDockerApplication.IMAGE_NAME;
 
     @CatalogConfig(label = "Image Tag", priority = 80)
+    @SetFromFlag("imageTag")
     ConfigKey<String> IMAGE_TAG = VanillaDockerApplication.IMAGE_TAG;
+
+    @SetFromFlag("entrypoint")
+    ConfigKey<List<String>> IMAGE_ENTRYPOINT = VanillaDockerApplication.IMAGE_ENTRYPOINT;
 
 }

--- a/dist/src/main/java/brooklyn/clocker/example/MicroserviceImageImpl.java
+++ b/dist/src/main/java/brooklyn/clocker/example/MicroserviceImageImpl.java
@@ -29,8 +29,6 @@ import org.apache.brooklyn.core.entity.Entities;
 import brooklyn.entity.container.docker.DockerInfrastructure;
 import brooklyn.entity.container.docker.application.VanillaDockerApplication;
 import brooklyn.location.docker.DockerLocation;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class MicroserviceImageImpl extends AbstractApplication implements MicroserviceImage {
     protected VanillaDockerApplication vanillaDockerApplication = null;
@@ -41,9 +39,12 @@ public class MicroserviceImageImpl extends AbstractApplication implements Micros
                 .configure("containerName", config().get(CONTAINER_NAME))
                 .configure("imageName", config().get(IMAGE_NAME))
                 .configure("imageTag", config().get(IMAGE_TAG))
+                .configure("entrypoint", config().get(IMAGE_ENTRYPOINT))
                 .configure("openPorts", config().get(OPEN_PORTS))
                 .configure("directPorts", config().get(DIRECT_PORTS))
-                .configure("env", config().get(DOCKER_CONTAINER_ENVIRONMENT)));
+                .configure("portBindings", config().get(PORT_BINDINGS))
+                .configure("env", config().get(DOCKER_CONTAINER_ENVIRONMENT))
+                .configure("volumeMappings", config().get(DOCKER_HOST_VOLUME_MAPPING)));
     }
 
     @Override

--- a/docker/src/main/java/brooklyn/entity/container/DockerAttributes.java
+++ b/docker/src/main/java/brooklyn/entity/container/DockerAttributes.java
@@ -75,6 +75,10 @@ public class DockerAttributes {
     public static final AttributeSensorAndConfigKey<String, String> DOCKER_IMAGE_TAG = ConfigKeys.newStringSensorAndConfigKey(
             "docker.image.tag", "The tag of the image to use", "latest");
 
+    public static final AttributeSensorAndConfigKey<List<String>, List<String>> DOCKER_IMAGE_ENTRYPOINT = ConfigKeys.newSensorAndConfigKey(
+            new TypeToken<List<String>>() { },
+            "docker.image.entrypoint", "Optional replacement for the image entrypoint command");
+
     public static final AttributeSensorAndConfigKey<String, String> DOCKER_HARDWARE_ID = ConfigKeys.newStringSensorAndConfigKey(
             "docker.hardwareId", "The ID of a Docker hardware type to use for a container", "small");
 

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerContainer.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerContainer.java
@@ -81,6 +81,9 @@ public interface DockerContainer extends BasicStartable, HasNetworkAddresses, Ha
     @SetFromFlag("imageTag")
     ConfigKey<String> DOCKER_IMAGE_TAG = DockerAttributes.DOCKER_IMAGE_TAG.getConfigKey();
 
+    @SetFromFlag("entrypoint")
+    ConfigKey<List<String>> DOCKER_IMAGE_ENTRYPOINT = DockerAttributes.DOCKER_IMAGE_ENTRYPOINT.getConfigKey();
+
     @SetFromFlag("hardwareId")
     ConfigKey<String> DOCKER_HARDWARE_ID = DockerAttributes.DOCKER_HARDWARE_ID.getConfigKey();
 

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerImpl.java
@@ -419,6 +419,14 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
         }
         options.env(env);
 
+        // Entrypoint
+        List<String> entrypoint = entity.config().get(DockerContainer.DOCKER_IMAGE_ENTRYPOINT);
+        if (entrypoint != null && entrypoint.size() > 0) {
+            options.entrypoint(entrypoint);
+            sensors().set(DockerAttributes.DOCKER_IMAGE_ENTRYPOINT, entrypoint);
+            entity.sensors().set(DockerAttributes.DOCKER_IMAGE_ENTRYPOINT, entrypoint);
+        }
+
         // Log for debugging without password
         LOG.debug("Docker options for {}: {}", entity, options);
 

--- a/docker/src/main/java/brooklyn/entity/container/docker/application/VanillaDockerApplication.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/application/VanillaDockerApplication.java
@@ -54,6 +54,9 @@ public interface VanillaDockerApplication extends VanillaSoftwareProcess {
     @SetFromFlag("imageTag")
     ConfigKey<String> IMAGE_TAG = DockerAttributes.DOCKER_IMAGE_TAG.getConfigKey();
 
+    @SetFromFlag("entrypoint")
+    ConfigKey<List<String>> IMAGE_ENTRYPOINT = DockerAttributes.DOCKER_IMAGE_ENTRYPOINT.getConfigKey();
+
     @SetFromFlag("useSsh")
     ConfigKey<Boolean> DOCKER_USE_SSH = ConfigKeys.newConfigKeyWithDefault(DockerAttributes.DOCKER_USE_SSH, Boolean.FALSE);
 

--- a/mesos/src/main/java/brooklyn/entity/mesos/task/marathon/MarathonTask.java
+++ b/mesos/src/main/java/brooklyn/entity/mesos/task/marathon/MarathonTask.java
@@ -18,7 +18,6 @@ package brooklyn.entity.mesos.task.marathon;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
 
 import org.apache.brooklyn.api.entity.Entity;
@@ -49,8 +48,7 @@ public interface MarathonTask extends MesosTask, HasNetworkAddresses, LocationOw
     ConfigKey<String> COMMAND = ConfigKeys.newStringConfigKey("marathon.task.command", "Marathon task command string");
 
     @SetFromFlag("args")
-    ConfigKey<List<String>> ARGS = ConfigKeys.newConfigKey(new TypeToken<List<String>>() { },
-            "marathon.task.args", "Marathon task command args", ImmutableList.<String>of());
+    ConfigKey<List<String>> ARGS = DockerContainer.DOCKER_IMAGE_ENTRYPOINT;
 
     @SetFromFlag("imageName")
     ConfigKey<String> DOCKER_IMAGE_NAME = DockerAttributes.DOCKER_IMAGE_NAME.getConfigKey();

--- a/mesos/src/main/java/brooklyn/entity/mesos/task/marathon/MarathonTaskImpl.java
+++ b/mesos/src/main/java/brooklyn/entity/mesos/task/marathon/MarathonTaskImpl.java
@@ -493,7 +493,7 @@ public class MarathonTaskImpl extends MesosTaskImpl implements MarathonTask {
             // Docker command or args
             String command = config().get(COMMAND);
             builder.putIfNotNull("command", command);
-            List<String> args = config().get(ARGS);
+            List<String> args = MutableList.copyOf(config().get(ARGS));
             builder.putIfNotNull("args", args);
         } else {
             // OS name for image


### PR DESCRIPTION
- Added extra config to `MicroserviceImage` and `MicroserviceDockerfile` for volumes.
- Includes support for setting the entrypoint for a container.
- Adds `portBindings` configuration keys