### PR TITLE
Added some more placement strategies

### DIFF
--- a/dist/src/main/assembly/files/blueprints/redis-label-placement.yaml
+++ b/dist/src/main/assembly/files/blueprints/redis-label-placement.yaml
@@ -1,0 +1,35 @@
+# Copyright 2014-2015 by Cloudsoft Corporation Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: redis-label-placement
+name: "Redis with SSD"
+description: |
+  Redis service with placement strategy that requires
+  a host that has the "ssd" label set on it.
+
+locations:
+- my-docker-cloud
+
+services:
+- type: org.apache.brooklyn.entity.nosql.redis.RedisStore
+  id: redis
+  name: "Redis SSD"
+  brooklyn.config:
+    install.version: 3.0.0
+    docker.container.strategies:
+    - $brooklyn:object:
+        type: "brooklyn.location.docker.strategy.LabelPlacementStrategy"
+        brooklyn.config:
+          docker.constraint.labels:
+          - "ssd"

--- a/docker/src/main/java/brooklyn/location/docker/strategy/HostnamePlacementStrategy.java
+++ b/docker/src/main/java/brooklyn/location/docker/strategy/HostnamePlacementStrategy.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014-2015 by Cloudsoft Corporation Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package brooklyn.location.docker.strategy;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
+
+import brooklyn.location.docker.DockerHostLocation;
+
+/**
+ * Strategy that requires the hostname of the Docker location to match a particular regexp.
+ */
+public class HostnamePlacementStrategy extends BasicDockerPlacementStrategy {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HostnamePlacementStrategy.class);
+
+    @SetFromFlag("hostname")
+    public static final ConfigKey<String> HOSTNAME_PATTERN = ConfigKeys.newStringConfigKey(
+            "docker.constraint.hostname",
+            "The pattern the required hostname must match");
+
+    @Override
+    public boolean apply(DockerHostLocation input) {
+        String constraint = Preconditions.checkNotNull(config().get(HOSTNAME_PATTERN), "pattern");
+        String hostname = Strings.nullToEmpty(input.getMachine().getHostname());
+        boolean match = hostname.matches(constraint);
+        LOG.debug("Hostname {} {} {}",
+                new Object[] { hostname, match ? "matches" : "not", constraint });
+
+        return match;
+    }
+}

--- a/docker/src/main/java/brooklyn/location/docker/strategy/LabelPlacementStrategy.java
+++ b/docker/src/main/java/brooklyn/location/docker/strategy/LabelPlacementStrategy.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014-2015 by Cloudsoft Corporation Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package brooklyn.location.docker.strategy;
+
+import java.util.List;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Functions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.reflect.TypeToken;
+
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
+
+import brooklyn.location.docker.DockerHostLocation;
+
+/**
+ * Placement strategy that checks labels on hosts.
+ */
+public class LabelPlacementStrategy extends BasicDockerPlacementStrategy {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LabelPlacementStrategy.class);
+
+    @SetFromFlag("labels")
+    public static final ConfigKey<List<String>> LABELS = ConfigKeys.newConfigKey(
+            new TypeToken<List<String>>() { },
+            "docker.constraint.labels",
+            "The list of required labels", ImmutableList.<String>of());
+
+    @Override
+    public boolean apply(DockerHostLocation input) {
+        Set<String> labels = MutableSet.copyOf(config().get(LABELS));
+        if (labels.isEmpty()) return true;
+        Set<String> tags = MutableSet.copyOf(Iterables.transform(input.getMachine().tags().getTags(), Functions.toStringFunction()));
+        labels.removeAll(tags);
+        LOG.debug("Host {} : Tags {} : Remaining {}",
+                new Object[] { input, Iterables.toString(tags), labels.isEmpty() ? "none" : Iterables.toString(labels) });
+
+        return labels.isEmpty();
+    }
+}


### PR DESCRIPTION
- `LabelPlacementStrategy` checks host tags against configured set of labels
- `HostnamePlacementStrategy` checks hostname matches regexp

Added provisional documentation to Wiki at https://github.com/brooklyncentral/clocker/wiki/PlacementStrategy