### PR TITLE
Ensure unique cointainer names if plan ID is set

### DIFF
--- a/docker/src/main/java/brooklyn/entity/container/DockerUtils.java
+++ b/docker/src/main/java/brooklyn/entity/container/DockerUtils.java
@@ -224,8 +224,18 @@ public class DockerUtils {
     public static Optional<String> getContainerName(Entity target) {
         return Optional.fromNullable(target.sensors().get(DockerContainer.DOCKER_CONTAINER_NAME))
                 .or(Optional.fromNullable(target.config().get(DockerContainer.DOCKER_CONTAINER_NAME)))
-                .or(Optional.fromNullable(target.config().get(BrooklynCampConstants.PLAN_ID)))
+                .or(Optional.fromNullable(getContainerNameFromPlan(target)))
                 .transform(DockerUtils.ALLOWED);
+    }
+
+    private static String getContainerNameFromPlan(Entity target) {
+        String planId = target.config().get(BrooklynCampConstants.PLAN_ID);
+        if (planId != null) {
+            //Plan IDs are not unique even in a single application
+            return planId + "_" + target.getId();
+        } else {
+            return null;
+        }
     }
 
     /* Generate the address to use to talk to another target entity. */

--- a/mesos/src/main/java/brooklyn/location/mesos/framework/marathon/MarathonLocation.java
+++ b/mesos/src/main/java/brooklyn/location/mesos/framework/marathon/MarathonLocation.java
@@ -161,6 +161,7 @@ public class MarathonLocation extends MesosFrameworkLocation implements MachineP
         String planId = entity.config().get(BrooklynCampConstants.PLAN_ID);
         String name = null;
         if (planId != null) {
+            //Plan IDs are not unique even in a single application
             name = planId + "/" + entity.getId();
         } else {
             name = entity.getId();


### PR DESCRIPTION
Plan IDs are not guaranteed to be unique even in a single application. This becomes a problem especially when using catalog items - can reference them only once per docker host.
Ensure unique container names when generated from the plan id.