### PR TITLE
Modify the start() method to deal with latest Brooklyn semantics

### DIFF
--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerImpl.java
@@ -62,6 +62,7 @@ import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
 import org.apache.brooklyn.core.feed.ConfigToAttributes;
 import org.apache.brooklyn.core.location.LocationConfigKeys;
+import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.core.location.dynamic.DynamicLocation;
 import org.apache.brooklyn.core.sensor.PortAttributeSensorAndConfigKey;
@@ -606,7 +607,12 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
     }
 
     @Override
-    public void start(Collection<? extends Location> locations) {
+    public void start(Collection<? extends Location> locs) {
+        if (locs != null && !locs.isEmpty()) {
+            addLocations(locs);
+        }
+        List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
+
         ServiceStateLogic.setExpectedState(this, Lifecycle.STARTING);
         try {
             Boolean started = config().get(SoftwareProcess.ENTITY_STARTED);

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerContainerImpl.java
@@ -608,9 +608,7 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
 
     @Override
     public void start(Collection<? extends Location> locs) {
-        if (locs != null && !locs.isEmpty()) {
-            addLocations(locs);
-        }
+        addLocations(locs);
         List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
 
         ServiceStateLogic.setExpectedState(this, Lifecycle.STARTING);

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerInfrastructureImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerInfrastructureImpl.java
@@ -373,9 +373,7 @@ public class DockerInfrastructureImpl extends AbstractApplication implements Doc
 
     @Override
     public void doStart(Collection<? extends Location> locs) {
-        if (locs != null && !locs.isEmpty()) {
-            addLocations(locs);
-        }
+        addLocations(locs);
         List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
 
         sensors().set(SERVICE_UP, Boolean.FALSE);

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerInfrastructureImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerInfrastructureImpl.java
@@ -65,6 +65,7 @@ import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.feed.ConfigToAttributes;
 import org.apache.brooklyn.core.location.BasicLocationDefinition;
 import org.apache.brooklyn.core.location.BasicLocationRegistry;
+import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.core.location.dynamic.LocationOwner;
 import org.apache.brooklyn.enricher.stock.Enrichers;
 import org.apache.brooklyn.entity.group.BasicGroup;
@@ -77,6 +78,7 @@ import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess.ChildStartableMode;
 import org.apache.brooklyn.entity.stock.DelegateEntity;
 import org.apache.brooklyn.policy.autoscaling.AutoScalerPolicy;
+import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.QuorumCheck.QuorumChecks;
 import org.apache.brooklyn.util.core.ResourceUtils;
@@ -370,7 +372,12 @@ public class DockerInfrastructureImpl extends AbstractApplication implements Doc
     }
 
     @Override
-    public void doStart(Collection<? extends Location> locations) {
+    public void doStart(Collection<? extends Location> locs) {
+        if (locs != null && !locs.isEmpty()) {
+            addLocations(locs);
+        }
+        List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
+
         sensors().set(SERVICE_UP, Boolean.FALSE);
         ServiceStateLogic.setExpectedState(this, Lifecycle.STARTING);
 

--- a/docker/src/main/java/brooklyn/entity/nosql/etcd/EtcdClusterImpl.java
+++ b/docker/src/main/java/brooklyn/entity/nosql/etcd/EtcdClusterImpl.java
@@ -77,9 +77,7 @@ public class EtcdClusterImpl extends DynamicClusterImpl implements EtcdCluster {
 
     @Override
     public void start(Collection<? extends Location> locs) {
-        if (locs != null && !locs.isEmpty()) {
-            addLocations(locs);
-        }
+        addLocations(locs);
         List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
 
         ServiceStateLogic.setExpectedState(this, Lifecycle.STARTING);
@@ -102,7 +100,7 @@ public class EtcdClusterImpl extends DynamicClusterImpl implements EtcdCluster {
     }
 
     protected void connectSensors() {
-        addPolicy(PolicySpec.create(MemberTrackingPolicy.class)
+        policies().add(PolicySpec.create(MemberTrackingPolicy.class)
                 .displayName("EtcdCluster node tracker")
                 .configure("sensorsToTrack", ImmutableSet.of(Attributes.HOSTNAME))
                 .configure("group", this));

--- a/docker/src/main/java/brooklyn/entity/nosql/etcd/EtcdClusterImpl.java
+++ b/docker/src/main/java/brooklyn/entity/nosql/etcd/EtcdClusterImpl.java
@@ -19,6 +19,7 @@
 package brooklyn.entity.nosql.etcd;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -45,11 +46,13 @@ import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic.ServiceNotUpLogic;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.feed.ConfigToAttributes;
+import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.core.sensor.DependentConfiguration;
 import org.apache.brooklyn.entity.group.AbstractMembershipTrackingPolicy;
 import org.apache.brooklyn.entity.group.Cluster;
 import org.apache.brooklyn.entity.group.DynamicCluster;
 import org.apache.brooklyn.entity.group.DynamicClusterImpl;
+import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
@@ -73,7 +76,12 @@ public class EtcdClusterImpl extends DynamicClusterImpl implements EtcdCluster {
     }
 
     @Override
-    public void start(Collection<? extends Location> locations) {
+    public void start(Collection<? extends Location> locs) {
+        if (locs != null && !locs.isEmpty()) {
+            addLocations(locs);
+        }
+        List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
+
         ServiceStateLogic.setExpectedState(this, Lifecycle.STARTING);
 
         connectSensors();

--- a/docker/src/main/java/brooklyn/networking/VirtualNetworkImpl.java
+++ b/docker/src/main/java/brooklyn/networking/VirtualNetworkImpl.java
@@ -61,9 +61,7 @@ public class VirtualNetworkImpl extends BasicStartableImpl implements VirtualNet
 
     @Override
     public void start(Collection<? extends Location> locs) {
-        if (locs != null && !locs.isEmpty()) {
-            addLocations(locs);
-        }
+        addLocations(locs);
         List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
 
         sensors().set(SERVICE_UP, Boolean.FALSE);

--- a/docker/src/main/java/brooklyn/networking/VirtualNetworkImpl.java
+++ b/docker/src/main/java/brooklyn/networking/VirtualNetworkImpl.java
@@ -16,6 +16,7 @@
 package brooklyn.networking;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,8 +31,10 @@ import org.apache.brooklyn.core.config.render.RendererHints;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
 import org.apache.brooklyn.core.feed.ConfigToAttributes;
+import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.entity.stock.BasicStartableImpl;
 import org.apache.brooklyn.entity.stock.DelegateEntity;
+import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.net.Cidr;
 import org.apache.brooklyn.util.text.StringFunctions;
@@ -57,7 +60,12 @@ public class VirtualNetworkImpl extends BasicStartableImpl implements VirtualNet
     }
 
     @Override
-    public void start(Collection<? extends Location> locations) {
+    public void start(Collection<? extends Location> locs) {
+        if (locs != null && !locs.isEmpty()) {
+            addLocations(locs);
+        }
+        List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
+
         sensors().set(SERVICE_UP, Boolean.FALSE);
 
         super.start(locations);

--- a/docker/src/main/java/brooklyn/networking/sdn/SdnProviderImpl.java
+++ b/docker/src/main/java/brooklyn/networking/sdn/SdnProviderImpl.java
@@ -209,9 +209,7 @@ public abstract class SdnProviderImpl extends BasicStartableImpl implements Dock
 
     @Override
     public void start(Collection<? extends Location> locs) {
-        if (locs != null && !locs.isEmpty()) {
-            addLocations(locs);
-        }
+        addLocations(locs);
         List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
 
         sensors().set(SERVICE_UP, Boolean.FALSE);

--- a/docker/src/main/java/brooklyn/networking/sdn/SdnProviderImpl.java
+++ b/docker/src/main/java/brooklyn/networking/sdn/SdnProviderImpl.java
@@ -17,6 +17,7 @@ package brooklyn.networking.sdn;
 
 import java.net.InetAddress;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -38,12 +39,14 @@ import org.apache.brooklyn.core.config.render.RendererHints;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityPredicates;
 import org.apache.brooklyn.core.feed.ConfigToAttributes;
+import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.entity.group.AbstractMembershipTrackingPolicy;
 import org.apache.brooklyn.entity.group.BasicGroup;
 import org.apache.brooklyn.entity.group.DynamicCluster;
 import org.apache.brooklyn.entity.group.DynamicGroup;
 import org.apache.brooklyn.entity.stock.BasicStartableImpl;
 import org.apache.brooklyn.entity.stock.DelegateEntity;
+import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.QuorumCheck.QuorumChecks;
 import org.apache.brooklyn.util.net.Cidr;
 
@@ -205,7 +208,12 @@ public abstract class SdnProviderImpl extends BasicStartableImpl implements Dock
     }
 
     @Override
-    public void start(Collection<? extends Location> locations) {
+    public void start(Collection<? extends Location> locs) {
+        if (locs != null && !locs.isEmpty()) {
+            addLocations(locs);
+        }
+        List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
+
         sensors().set(SERVICE_UP, Boolean.FALSE);
 
         // Add ouserlves as an extension to the Docker location

--- a/mesos/src/main/java/brooklyn/entity/mesos/MesosClusterImpl.java
+++ b/mesos/src/main/java/brooklyn/entity/mesos/MesosClusterImpl.java
@@ -242,9 +242,7 @@ public class MesosClusterImpl extends AbstractApplication implements MesosCluste
 
     @Override
     public void doStart(Collection<? extends Location> locs) {
-        if (locs != null && !locs.isEmpty()) {
-            addLocations(locs);
-        }
+        addLocations(locs);
         List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
 
         sensors().set(SERVICE_UP, Boolean.FALSE);

--- a/mesos/src/main/java/brooklyn/entity/mesos/MesosClusterImpl.java
+++ b/mesos/src/main/java/brooklyn/entity/mesos/MesosClusterImpl.java
@@ -63,6 +63,7 @@ import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.location.BasicLocationDefinition;
 import org.apache.brooklyn.core.location.BasicLocationRegistry;
 import org.apache.brooklyn.core.location.LocationConfigKeys;
+import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.core.location.dynamic.LocationOwner;
 import org.apache.brooklyn.entity.group.BasicGroup;
@@ -240,7 +241,12 @@ public class MesosClusterImpl extends AbstractApplication implements MesosCluste
     }
 
     @Override
-    public void doStart(Collection<? extends Location> locations) {
+    public void doStart(Collection<? extends Location> locs) {
+        if (locs != null && !locs.isEmpty()) {
+            addLocations(locs);
+        }
+        List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
+
         sensors().set(SERVICE_UP, Boolean.FALSE);
         ServiceStateLogic.setExpectedState(this, Lifecycle.STARTING);
 

--- a/mesos/src/main/java/brooklyn/entity/mesos/framework/MesosFrameworkImpl.java
+++ b/mesos/src/main/java/brooklyn/entity/mesos/framework/MesosFrameworkImpl.java
@@ -43,6 +43,7 @@ import org.apache.brooklyn.core.entity.EntityFunctions;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
 import org.apache.brooklyn.core.feed.ConfigToAttributes;
+import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.entity.group.Cluster;
 import org.apache.brooklyn.entity.group.DynamicCluster;
 import org.apache.brooklyn.entity.stock.BasicStartableImpl;
@@ -89,7 +90,12 @@ public class MesosFrameworkImpl extends BasicStartableImpl implements MesosFrame
     }
 
     @Override
-    public void start(Collection<? extends Location> locations) {
+    public void start(Collection<? extends Location> locs) {
+        if (locs != null && !locs.isEmpty()) {
+            addLocations(locs);
+        }
+        List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
+
         sensors().set(SERVICE_UP, Boolean.FALSE);
 
         connectSensors();

--- a/mesos/src/main/java/brooklyn/entity/mesos/framework/MesosFrameworkImpl.java
+++ b/mesos/src/main/java/brooklyn/entity/mesos/framework/MesosFrameworkImpl.java
@@ -91,9 +91,7 @@ public class MesosFrameworkImpl extends BasicStartableImpl implements MesosFrame
 
     @Override
     public void start(Collection<? extends Location> locs) {
-        if (locs != null && !locs.isEmpty()) {
-            addLocations(locs);
-        }
+        addLocations(locs);
         List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
 
         sensors().set(SERVICE_UP, Boolean.FALSE);

--- a/mesos/src/main/java/brooklyn/entity/mesos/framework/marathon/MarathonFrameworkImpl.java
+++ b/mesos/src/main/java/brooklyn/entity/mesos/framework/marathon/MarathonFrameworkImpl.java
@@ -166,9 +166,7 @@ public class MarathonFrameworkImpl extends MesosFrameworkImpl implements Maratho
  
     @Override
     public void start(Collection<? extends Location> locs) {
-        if (locs != null && !locs.isEmpty()) {
-            addLocations(locs);
-        }
+        addLocations(locs);
         List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
 
         ServiceStateLogic.setExpectedState(this, Lifecycle.STARTING);

--- a/mesos/src/main/java/brooklyn/entity/mesos/framework/marathon/MarathonFrameworkImpl.java
+++ b/mesos/src/main/java/brooklyn/entity/mesos/framework/marathon/MarathonFrameworkImpl.java
@@ -43,12 +43,14 @@ import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
 import org.apache.brooklyn.core.location.BasicLocationDefinition;
 import org.apache.brooklyn.core.location.BasicLocationRegistry;
+import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.core.location.dynamic.LocationOwner;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.feed.http.HttpFeed;
 import org.apache.brooklyn.feed.http.HttpPollConfig;
 import org.apache.brooklyn.feed.http.HttpValueFunctions;
 import org.apache.brooklyn.feed.http.JsonFunctions;
+import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.guava.Functionals;
 import org.apache.brooklyn.util.net.Urls;
@@ -163,7 +165,12 @@ public class MarathonFrameworkImpl extends MesosFrameworkImpl implements Maratho
     }
  
     @Override
-    public void start(Collection<? extends Location> locations) {
+    public void start(Collection<? extends Location> locs) {
+        if (locs != null && !locs.isEmpty()) {
+            addLocations(locs);
+        }
+        List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
+
         ServiceStateLogic.setExpectedState(this, Lifecycle.STARTING);
 
         connectSensors();

--- a/mesos/src/main/java/brooklyn/entity/mesos/task/MesosTaskImpl.java
+++ b/mesos/src/main/java/brooklyn/entity/mesos/task/MesosTaskImpl.java
@@ -69,9 +69,7 @@ public class MesosTaskImpl extends BasicStartableImpl implements MesosTask {
 
     @Override
     public void start(Collection<? extends Location> locs) {
-        if (locs != null && !locs.isEmpty()) {
-            addLocations(locs);
-        }
+        addLocations(locs);
         List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
 
         sensors().set(SERVICE_UP, Boolean.FALSE);

--- a/mesos/src/main/java/brooklyn/entity/mesos/task/MesosTaskImpl.java
+++ b/mesos/src/main/java/brooklyn/entity/mesos/task/MesosTaskImpl.java
@@ -16,6 +16,7 @@
 package brooklyn.entity.mesos.task;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,8 +24,10 @@ import org.slf4j.LoggerFactory;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.config.render.RendererHints;
 import org.apache.brooklyn.core.feed.ConfigToAttributes;
+import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.entity.stock.BasicStartableImpl;
 import org.apache.brooklyn.entity.stock.DelegateEntity;
+import org.apache.brooklyn.util.collections.MutableList;
 
 import brooklyn.entity.mesos.MesosCluster;
 import brooklyn.entity.mesos.framework.MesosFramework;
@@ -65,7 +68,12 @@ public class MesosTaskImpl extends BasicStartableImpl implements MesosTask {
     }
 
     @Override
-    public void start(Collection<? extends Location> locations) {
+    public void start(Collection<? extends Location> locs) {
+        if (locs != null && !locs.isEmpty()) {
+            addLocations(locs);
+        }
+        List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
+
         sensors().set(SERVICE_UP, Boolean.FALSE);
 
         super.start(locations);

--- a/mesos/src/main/java/brooklyn/entity/mesos/task/marathon/MarathonTaskImpl.java
+++ b/mesos/src/main/java/brooklyn/entity/mesos/task/marathon/MarathonTaskImpl.java
@@ -249,9 +249,7 @@ public class MarathonTaskImpl extends MesosTaskImpl implements MarathonTask {
 
     @Override
     public void start(Collection<? extends Location> locs) {
-        if (locs != null && !locs.isEmpty()) {
-            addLocations(locs);
-        }
+        addLocations(locs);
         List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
 
         super.start(locations);

--- a/mesos/src/main/java/brooklyn/entity/mesos/task/marathon/MarathonTaskImpl.java
+++ b/mesos/src/main/java/brooklyn/entity/mesos/task/marathon/MarathonTaskImpl.java
@@ -64,6 +64,7 @@ import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
 import org.apache.brooklyn.core.feed.ConfigToAttributes;
 import org.apache.brooklyn.core.location.LocationConfigKeys;
+import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.core.location.dynamic.DynamicLocation;
 import org.apache.brooklyn.core.sensor.DependentConfiguration;
@@ -247,7 +248,12 @@ public class MarathonTaskImpl extends MesosTaskImpl implements MarathonTask {
     }
 
     @Override
-    public void start(Collection<? extends Location> locations) {
+    public void start(Collection<? extends Location> locs) {
+        if (locs != null && !locs.isEmpty()) {
+            addLocations(locs);
+        }
+        List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
+
         super.start(locations);
 
         ServiceStateLogic.setExpectedState(this, Lifecycle.STARTING);

--- a/mesos/src/main/java/brooklyn/networking/sdn/mesos/CalicoModuleImpl.java
+++ b/mesos/src/main/java/brooklyn/networking/sdn/mesos/CalicoModuleImpl.java
@@ -186,9 +186,7 @@ public class CalicoModuleImpl extends BasicStartableImpl implements CalicoModule
 
     @Override
     public void start(Collection<? extends Location> locs) {
-        if (locs != null && !locs.isEmpty()) {
-            addLocations(locs);
-        }
+        addLocations(locs);
         List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
 
         sensors().set(SERVICE_UP, Boolean.FALSE);

--- a/mesos/src/main/java/brooklyn/networking/sdn/mesos/CalicoModuleImpl.java
+++ b/mesos/src/main/java/brooklyn/networking/sdn/mesos/CalicoModuleImpl.java
@@ -43,6 +43,7 @@ import org.apache.brooklyn.core.effector.ssh.SshEffectorTasks;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityPredicates;
 import org.apache.brooklyn.core.feed.ConfigToAttributes;
+import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.core.location.Machines;
 import org.apache.brooklyn.entity.group.BasicGroup;
 import org.apache.brooklyn.entity.group.DynamicGroup;
@@ -184,7 +185,12 @@ public class CalicoModuleImpl extends BasicStartableImpl implements CalicoModule
     public Object getNetworkMutex() { return networkMutex; }
 
     @Override
-    public void start(Collection<? extends Location> locations) {
+    public void start(Collection<? extends Location> locs) {
+        if (locs != null && !locs.isEmpty()) {
+            addLocations(locs);
+        }
+        List<Location> locations = MutableList.copyOf(Locations.getLocationsCheckingAncestors(locs, this));
+
         sensors().set(SERVICE_UP, Boolean.FALSE);
 
         // Add ouserlves as an extension to the Docker location


### PR DESCRIPTION
Changed all `#start(Collection)` methods to use `Locations#getLocationsCheckingAncestors(Collection, Entity)`