### PR TITLE
Fix issue where Marathon ports are not mapped correctly

### DIFF
--- a/mesos/src/main/java/brooklyn/entity/mesos/MesosCluster.java
+++ b/mesos/src/main/java/brooklyn/entity/mesos/MesosCluster.java
@@ -91,7 +91,7 @@ public interface MesosCluster extends StartableApplication, LocationOwner<MesosL
 
     @SetFromFlag("scanInterval")
     ConfigKey<Duration> SCAN_INTERVAL = ConfigKeys.newConfigKey(Duration.class,
-            "mesos.scanInterval", "Interval between scans of Mesos tasks and frameworks", Duration.TEN_SECONDS);
+            "mesos.scanInterval", "Interval between scans of Mesos tasks and frameworks", Duration.ONE_MINUTE);
 
     AttributeSensor<List<String>> MESOS_FRAMEWORK_LIST = Sensors.newSensor(new TypeToken<List<String>>() { }, "mesos.frameworks.list", "List of Mesos frameworks");
     AttributeSensor<List<String>> MESOS_SLAVE_LIST = Sensors.newSensor(new TypeToken<List<String>>() { }, "mesos.slaves.list", "List of Mesos slaves");

--- a/mesos/src/main/java/brooklyn/entity/mesos/MesosClusterImpl.java
+++ b/mesos/src/main/java/brooklyn/entity/mesos/MesosClusterImpl.java
@@ -320,7 +320,7 @@ public class MesosClusterImpl extends AbstractApplication implements MesosCluste
 
         HttpFeed.Builder httpFeedBuilder = HttpFeed.builder()
                 .entity(this)
-                .period(15, TimeUnit.SECONDS)
+                .period(1, TimeUnit.MINUTES)
                 .baseUri(sensors().get(Attributes.MAIN_URI))
                 .credentialsIfNotNull(config().get(MESOS_USERNAME), config().get(MESOS_PASSWORD))
                 .poll(new HttpPollConfig<Boolean>(SERVICE_UP)


### PR DESCRIPTION
The `mapped.docker.port.XXXX` sensors were not being populated, due to a delay in setting the location on entities.