### PR TITLE
Karaf features for clocker

### DIFF
--- a/console/pom.xml
+++ b/console/pom.xml
@@ -15,8 +15,8 @@
     limitations under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <packaging>war</packaging>
 
@@ -39,8 +39,11 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.4</version>
+                <version>${maven-war-plugin.version}</version>
                 <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
                     <webResources>
                         <resource>
                             <directory>src/main/webapp</directory>
@@ -60,11 +63,34 @@
                 </configuration>
             </plugin>
             <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <configuration>
-                <skipTests>true</skipTests>
-              </configuration>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <supportedProjectTypes>
+                        <supportedProjectType>war</supportedProjectType>
+                    </supportedProjectTypes>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Version>${project.version}</Bundle-Version>
+                        <Web-ContextPath>/console</Web-ContextPath>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.brooklyn.clocker</groupId>
+        <artifactId>brooklyn-clocker-parent</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>brooklyn-clocker-features</artifactId>
+
+    <packaging>feature</packaging>
+
+    <name>Clocker Karaf Features</name>
+    <description>Clocker features for Karaf deployment.</description>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.karaf.tooling</groupId>
+                    <artifactId>karaf-maven-plugin</artifactId>
+                    <version>4.0.4</version>
+                    <extensions>true</extensions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-maven-plugin</artifactId>
+
+                <configuration>
+                    <startLevel>50</startLevel>
+                    <aggregateFeatures>true</aggregateFeatures>
+                    <resolver>(obr)</resolver>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -33,6 +33,44 @@
     <name>Clocker Karaf Features</name>
     <description>Clocker features for Karaf deployment.</description>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.karaf</groupId>
+            <artifactId>apache-karaf</artifactId>
+            <type>zip</type>
+            <version>${karaf.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- same as in brooklyn-clocker-dist -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>brooklyn-clocker-docker</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>brooklyn-clocker-mesos</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>brooklyn-clocker-jsgui</artifactId>
+            <version>${project.parent.version}</version>
+            <type>war</type>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>brooklyn-clocker-console</artifactId>
+            <version>${project.parent.version}</version>
+            <type>war</type>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>
@@ -48,11 +86,27 @@
             <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
-
+                <executions>
+                    <execution>
+                        <id>validate-features</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
                     <startLevel>50</startLevel>
-                    <aggregateFeatures>true</aggregateFeatures>
-                    <resolver>(obr)</resolver>
+                    <aggregateFeatures>false</aggregateFeatures>
+                    <addBundlesToPrimaryFeature>false</addBundlesToPrimaryFeature>
+                    <checkDependencyChange>false</checkDependencyChange>
+                    <failOnDependencyChange>false</failOnDependencyChange>
+                    <logDependencyChanges>false</logDependencyChanges>
+                    <overwriteChangedDependencies>true</overwriteChangedDependencies>
+                    <!-- for karaf:verify -->
+                    <descriptors>
+                        <descriptor>file:${project.build.directory}/feature/feature.xml</descriptor>
+                    </descriptors>
                 </configuration>
             </plugin>
         </plugins>

--- a/features/src/main/feature/feature.xml
+++ b/features/src/main/feature/feature.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.2.0">
+
+    <repository>mvn:org.apache.brooklyn/brooklyn-features/${brooklyn.version}/xml/features</repository>
+
+    <feature name='${project.artifactId}' description='${project.name}' version='${project.version}'>
+        <details>${project.description}</details>
+        <!-- <config>foo=bar</config> -->
+    </feature>
+
+    <feature name="clocker-jsgui" version="${project.version}" description="Brooklyn Clocker  REST JavaScript Web GUI">
+        <details>JavaScript+HTML GUI for interacting with clocker, building on Brooklyn JS GUI and using the Brooklyn REST API</details>
+        
+        <bundle>mvn:io.brooklyn.clocker/brooklyn-clocker-jsgui/${project.version}/war</bundle>
+        <feature>war</feature>
+    </feature>
+
+    <feature name="clocker-console" version="${project.version}" description="Clocker Web UI">
+        <details>Web UI for interacting with Clocker</details>
+
+        <bundle>mvn:io.brooklyn.clocker/brooklyn-clocker-console/${project.version}/war</bundle>
+        <feature>war</feature>
+    </feature>
+
+    <feature name="clocker-docker" version="${project.version}" description="Clocker Docker Integration">
+        <details>Clocker Brooklyn entities and locations for Docker integration.</details>
+
+        <bundle>mvn:io.brooklyn.clocker/brooklyn-clocker-docker/${project.version}</bundle>
+        <feature version="${brooklyn.version}">brooklyn-core</feature>
+    </feature>
+
+    <feature name="clocker-mesos" version="${project.version}" description="Clocker Mesos Integration">
+        <details>Clocker Brooklyn entities and locations for Mesos integration.</details>
+
+        <bundle>mvn:io.brooklyn.clocker/brooklyn-clocker-mesos/${project.version}</bundle>
+        <feature version="${brooklyn.version}">brooklyn-core</feature>
+    </feature>
+
+    <feature name="clocker-all" version="${project.version}" description="Full deployment of Clocker">
+        <feature dependency="true" version="${project.version}">clocker-docker</feature>
+        <feature dependency="true" version="${project.version}">clocker-mesos</feature>
+        <feature dependency="true" version="${project.version}">clocker-jsgui</feature>
+        <feature dependency="true" version="${project.version}">clocker-console</feature>
+    </feature>
+
+</features>

--- a/features/src/main/feature/feature.xml
+++ b/features/src/main/feature/feature.xml
@@ -18,18 +18,21 @@
 -->
 <features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.2.0">
 
-    <repository>mvn:org.apache.brooklyn/brooklyn-features/${brooklyn.version}/xml/features</repository>
+    <repository>mvn:org.apache.karaf.features/framework/${karaf.version}/xml/features</repository>
+    <repository>mvn:org.apache.karaf.features/standard/${karaf.version}/xml/features</repository>
+    <repository>mvn:org.apache.karaf.features/enterprise/${karaf.version}/xml/features</repository>
+    <repository>mvn:org.apache.karaf.features/spring/${karaf.version}/xml/features</repository>
 
-    <feature name='${project.artifactId}' description='${project.name}' version='${project.version}'>
-        <details>${project.description}</details>
-        <!-- <config>foo=bar</config> -->
-    </feature>
+    <repository>mvn:org.apache.brooklyn/brooklyn-features/${brooklyn.version}/xml/features</repository>
 
     <feature name="clocker-jsgui" version="${project.version}" description="Brooklyn Clocker  REST JavaScript Web GUI">
         <details>JavaScript+HTML GUI for interacting with clocker, building on Brooklyn JS GUI and using the Brooklyn REST API</details>
         
         <bundle>mvn:io.brooklyn.clocker/brooklyn-clocker-jsgui/${project.version}/war</bundle>
         <feature>war</feature>
+
+        <!-- FIXME: workaround that avoids validation failure, but messes up feature:uninstall -->
+        <feature dependency="true">framework</feature>
     </feature>
 
     <feature name="clocker-console" version="${project.version}" description="Clocker Web UI">
@@ -37,6 +40,9 @@
 
         <bundle>mvn:io.brooklyn.clocker/brooklyn-clocker-console/${project.version}/war</bundle>
         <feature>war</feature>
+
+        <!-- FIXME: workaround that avoids validation failure, but messes up feature:uninstall -->
+        <feature dependency="true">framework</feature>
     </feature>
 
     <feature name="clocker-docker" version="${project.version}" description="Clocker Docker Integration">
@@ -44,20 +50,28 @@
 
         <bundle>mvn:io.brooklyn.clocker/brooklyn-clocker-docker/${project.version}</bundle>
         <feature version="${brooklyn.version}">brooklyn-core</feature>
+        <feature version="${brooklyn.version}">brooklyn-software-base</feature>
+        <feature version="${brooklyn.version}">brooklyn-locations-jclouds</feature>
+        <bundle dependency="true">mvn:io.brooklyn.networking/brooklyn-networking-common/${brooklyn.version}</bundle>
+        <bundle dependency="true">mvn:io.brooklyn.networking/brooklyn-networking-portforwarding/${brooklyn.version}</bundle>
+
+        <!-- FIXME: workaround that avoids validation failure, but messes up feature:uninstall -->
+        <feature dependency="true">framework</feature>
+        <feature dependency="true">aries-blueprint</feature>
     </feature>
 
     <feature name="clocker-mesos" version="${project.version}" description="Clocker Mesos Integration">
         <details>Clocker Brooklyn entities and locations for Mesos integration.</details>
 
         <bundle>mvn:io.brooklyn.clocker/brooklyn-clocker-mesos/${project.version}</bundle>
-        <feature version="${brooklyn.version}">brooklyn-core</feature>
+        <feature version="${project.version}">clocker-docker</feature>
     </feature>
 
-    <feature name="clocker-all" version="${project.version}" description="Full deployment of Clocker">
-        <feature dependency="true" version="${project.version}">clocker-docker</feature>
-        <feature dependency="true" version="${project.version}">clocker-mesos</feature>
-        <feature dependency="true" version="${project.version}">clocker-jsgui</feature>
-        <feature dependency="true" version="${project.version}">clocker-console</feature>
-    </feature>
+<!--    <feature name="clocker-all" version="${project.version}" description="Full deployment of Clocker">
+        <feature version="${project.version}">clocker-docker</feature>
+        <feature version="${project.version}">clocker-mesos</feature>
+        <feature version="${project.version}">clocker-jsgui</feature>
+        <feature version="${project.version}">clocker-console</feature>
+    </feature>-->
 
 </features>

--- a/jsgui/pom.xml
+++ b/jsgui/pom.xml
@@ -55,6 +55,7 @@
               <addClasspath>true</addClasspath>
               <classpathPrefix>lib/</classpathPrefix>
             </manifest>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
           <overlays>
             <overlay>
@@ -67,6 +68,29 @@
 -->
             </overlay>
           </overlays>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <supportedProjectTypes>
+            <supportedProjectType>war</supportedProjectType>
+          </supportedProjectTypes>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+            <Web-ContextPath>/</Web-ContextPath>
+          </instructions>
         </configuration>
       </plugin>
      </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <!-- Dependencies -->
         <jclouds.groupId>org.apache.jclouds</jclouds.groupId> <!-- JCLOUDS_GROUPID_VERSION -->
         <jclouds.version>1.9.2</jclouds.version> <!-- JCLOUDS_VERSION -->
+        <karaf.version>4.0.4</karaf.version>
 
         <!-- Testing -->
         <testng.version>6.8</testng.version>

--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,7 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <modules>
         <module>patches</module>
@@ -25,7 +22,8 @@
         <module>mesos</module>
         <module>console</module>
         <module>dist</module>
-    </modules>
+        <module>features</module>
+  </modules>
 
     <parent>
         <groupId>org.apache.brooklyn</groupId>
@@ -59,7 +57,7 @@
         <excludedTestGroups>Integration,Live,WIP</excludedTestGroups>
 
         <!-- Deployment -->
-        <gpg.passphrase />
+        <gpg.passphrase/>
     </properties>
 
     <scm>
@@ -368,7 +366,7 @@
                             <author>false</author>
                             <quiet>true</quiet>
                             <aggregate>false</aggregate>
-                            <detectLinks />
+                            <detectLinks/>
                         </configuration>
                         <executions>
                             <execution>


### PR DESCRIPTION
I had to stop at brooklyn-software-jclouds, which uses a version of guava incompatible with that used by jclouds (at least from a semantic versioning perspective). This problem is still unresolved in brooklyn-features, so it spilled here.

We can disable validation for the time being, but this will only help making the build succeed - but installing those features in karaf will still fail.