### PR TITLE
Allow VaniillaDockerApplication entity to execute custom commands

### DIFF
--- a/docker/src/main/java/brooklyn/entity/container/docker/application/VanillaDockerApplication.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/application/VanillaDockerApplication.java
@@ -81,7 +81,7 @@ public interface VanillaDockerApplication extends VanillaSoftwareProcess {
     @SetFromFlag("links")
     ConfigKey<List<Entity>> DOCKER_LINKS = DockerAttributes.DOCKER_LINKS;
 
-    ConfigKey<Boolean> SKIP_ENTITY_START = ConfigKeys.newConfigKeyWithDefault(BrooklynConfigKeys.SKIP_ENTITY_START, Boolean.TRUE);
+    ConfigKey<Boolean> SKIP_ENTITY_INSTALLATION = ConfigKeys.newConfigKeyWithDefault(BrooklynConfigKeys.SKIP_ENTITY_INSTALLATION, Boolean.TRUE);
     
     ConfigKey<Boolean> SKIP_ON_BOX_BASE_DIR_RESOLUTION = ConfigKeys.newConfigKeyWithDefault(BrooklynConfigKeys.SKIP_ON_BOX_BASE_DIR_RESOLUTION, Boolean.TRUE);
 


### PR DESCRIPTION
Only skip the `install()` phase of `SoftwareProcess` startup for Docker containers, allowing extra commands to be configured for `customize()`, `launch()` and `isRunning()` where required. This gives more flexibility when using Docker images that need files copied to them or extra scripts executed.