### PR TITLE
Added automatic QA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,32 +15,29 @@
 sudo: false
 language: java
 jdk:
-  - oraclejdk7
+  - oraclejdk8
 
-script: mvn clean install
+script: travis_wait 60 mvn clean install -U --settings dist/target/test-classes/travis_maven_settings.xml -P QA -Ds3-upload.destination=brooklyn-clocker-QA-${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT}-dist.tar.gz -Ds3-upload.accessKey=$AWS_IDENTITY -Ds3-upload.secretKey=$AWS_CREDENTIAL  -Dbrooklyn-test.localPropertiesAdditions="brooklyn.location.jclouds.softlayer.identity=$SOFTLAYER_USERNAME,brooklyn.location.jclouds.softlayer.credential=$SOFTLAYER_KEY,brooklyn.location.jclouds.aws-ec2.identity=$AWS_IDENTITY,brooklyn.location.jclouds.aws-ec2.credential=$AWS_CREDENTIAL" -Dbrooklyn-test.ampTestClusterPassword=$AMP_CLUSTER_PASSWORD -Dbrooklyn-test.distributionUrl=https://s3-eu-west-1.amazonaws.com/clocker-latest/brooklyn-clocker-QA-${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT}-dist.tar.gz
 
 after_success:
   - .buildscript/deploy_snapshot.sh
 
-before_deploy: "mkdir artifacts && mv dist/target/brooklyn-clocker-dist.tar.gz artifacts/brooklyn-clocker-${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT}-dist.tar.gz"
-
-deploy:
-  - provider: s3
-    access_key_id: AKIAJL5SMCB2JZCJ2WAQ
-    secret_access_key:
-      secure: JdnmzeTNcG52cKVx12tn05ojgPxwZ4bAdkYbSV/Uy863COhpx3glz1CakUEoDLLo606jGQuYbOiiL9KQrAJCsQe+xLsBA7NRcAoZjxhotYURdRSDYoOzeFHVWTngDOBJQ/irKzH6lYEnDowdV+lG/eAeDSD9eyo5EoEfFjFQR/I=
-    skip_cleanup: true
-    bucket: clocker-latest
-    acl: public_read
-    region: eu-west-1
-    local-dir: artifacts
-    on:
-      branch: master
-
 env:
   global:
-    - secure: "BrRh52Ae8fkDqBRGOgFCi89DKDtTWnvZju3K1ntV0kC0nP0pIdKKKgCKZC9u8EmFYF8HZnHagqn3VSRX2+tASwo0xauY0urV4GlMUp38+Dnzt1Kg9XKL/m6aQdEu+EjhMm6KCar5CKZ1TdO36RWZdY6yM/0QZMSS6HqrdlDc8eo="
-    - secure: "T8804sbwQgUGniJhfC/DdIwQ3Tt4UdyGVJWFzdVXKk+zSVm302PG1Ibp3A4kzMy9MUbYspRNh/lNmGsGN0DR1pElDqAO6zVDo7+KBaU7/gEoTjVigvhYcV1Y4E3X+KqXY1fykmLC4zjGpdmkWa602SX7EXpiJ0o31hujFXA3ElQ="
+  - secure: "BrRh52Ae8fkDqBRGOgFCi89DKDtTWnvZju3K1ntV0kC0nP0pIdKKKgCKZC9u8EmFYF8HZnHagqn3VSRX2+tASwo0xauY0urV4GlMUp38+Dnzt1Kg9XKL/m6aQdEu+EjhMm6KCar5CKZ1TdO36RWZdY6yM/0QZMSS6HqrdlDc8eo="
+  - secure: "T8804sbwQgUGniJhfC/DdIwQ3Tt4UdyGVJWFzdVXKk+zSVm302PG1Ibp3A4kzMy9MUbYspRNh/lNmGsGN0DR1pElDqAO6zVDo7+KBaU7/gEoTjVigvhYcV1Y4E3X+KqXY1fykmLC4zjGpdmkWa602SX7EXpiJ0o31hujFXA3ElQ="
+#  AWS
+  - secure: "f0Jufx8S+6riOaScXbuXUudtEL5I+eyAZZd8xJzeGp9Zt9xvME+9Erjw1WyGV1g/64f+pfaKc2As39AD/FkY6PQmfnfUHKuudXnrHIAovkFZVwcBjlDNrrf5l1S3aJyjw2SkaA5bwOGlRF+h90fsjsZSD95jFIH4fWZDZo4FWXfE0s8fooWQyGKL77DT2AMWO5crkmo35YYM78PoLNKZTmf2cRJlUQU+qjgxdisQbABv6JotjGyQIqEudX6B0kwXJTpjb6hcBYDgvGTXIrKxzbO7ws3VbvGX3mKJq3G3RL/uJ8e7kJxJ7CaMErlrjO7GJkDQuHGyecYa5WlN2Skm88KHOUwnVmyTD4vB/WAZwsXcZ93cL+pBG880wMm64ge19W7N+Yt3iU1wL5XFGwt6XwWjEOjthQUW0XIv6t3LRUC9J1b4fT81GenO58VM5vOs3JghjY0cF2vQJ6Tl22pDwWoDVLCvQe5T5mnMH/TWZ3TYXeAnp0elMk6DZqWiS8RTFDMDi7ex5TntfCp2baDcswNzE8NsLPhJ74qyDkb9eFuDVVzW/o4nYhdYg9FBnPBBe6IAKyYWNgnRjNL9OTPhYnQxXsPrQ8ZHRbl0OTWBRndZ2oVIjTs43GbYwnbQSLuRrmWZN+XduTSPRdQC/U8I62wJKkuqSg3tr26doWIHR0I="
+  - secure: "cqfjKBc4GwYOq4nUAT1br8DbdwYrbEbzpjzms0yvubJFwanl22tNDvd2mpAUoNbBTxvmDSTbMvBSFij3QV+PokW/t80sqXvH2CRVbHsKRBLMY7sqIfuazmO4bpO9QdFPpo21TizGWXF3c62AWP8eq9MGWxRF/UFV5/srYrzXbW8WLzbi0ixPItnrcwztILIwAlkHcyddHXol02t0G1OC3oSJzCvCjrjK/zZEi+2aF9R9vyZViUKUe+LeYT1lrdTSEOSPANahGDCtRU6PydMGs8hLNTNFp+eHLO7h1OxtE8//n/P5mES9qTo7m9GO/rwATTCjkbb7qQ6xWzzim6xMjFgx+rMBZEKzhE3hLMmvrLEINlGCrcNupyWFtNPBO/eW1+CEG72fbWq0qz3oBxzIy95RRNyUC+WxPCqp9jr5NJDI8H+d4ED4Pwweisc4/rZDKil5/lH+6eEWWbunXLo0SPVuXYfOXUeqZ72SIhqwPBfD9lGu7C+Tf5DIWgXsL7PEfaUhzKN+D392EuM1PwsUzIvCUqbUcKoJZ/17nmUQEVyxJnT+Ik+3hQwKRRvp7Vg6NeNrvmeshj0+19N2Gzh/QmQfQM4KSoNiP9YFFK3L15X2UqLodvH+9XNDIy/01zo3lwoqNgHpeCr8siKwIWerGIuxq1NYo8uC0sh7h5G90+A="
+
+
+#  Test AMP Password
+  - secure: "H7LFeJnJy7T7X8AijeaU1ILLGjbwqJyp+2GAt22CM6YdcrlaxFWtKfaHIZAhRJm3jDThhTAXThBr3qXO2relxpq0uvwvjW0f54+HUaKFp6OE2qGjdUbw/lLIT6DQ84r9tUOC335WE8QPZCdnTLd32+kZAVH4EnLS38f04+DHONrLv54PfTjpurnypCezoVp53s2oGVvqp0yPf09IqL57r47NCUrcHTTbM2dxdn4CzXCAjNnzO5gtUEsWY7mlWBg0lnzBfaZIt3JXcI8GqcrHfRZNSSBwreQASTca4dw5PAM5pUMi/A+1m3WKdMSH+DiEbWX+SgGKkxy565EYMdqgSGO18PPAdh15VPxDg6l6F+GlO58j4j05YRMfi4cw5WF54/FkLQzeH8/RmpTjfj+GpIs6XOWF2M68m06ceKAfdS31qI3xoP3c8DE5pgi4R3SKK8ddzG5P5V4k3tMFOsCg54g+LYnhzmTvwP7fok+Bd4q+m6goAl5g84V4OEzGmHhtkvorYQyO+FRwyA+oRH3G8yaVj2ljqOjHk83334x3RRVfZB7mLBJIRoVI4ZsFRu2j+0Nozy4JnVp++OcTtVn8I57rMRJAWzJqGyWM6r/UVI6JTGIcUWuNMH0AI+KMsqD1qlUXGUAS/XuCJJLUXyHScLhbPE+PIcMjgPJO6afz9ek="
+#  Softlayer
+  - secure: "HDTN8nYiOx+B8Wyvd/fcJGnTLq3zHx+56MhZGtfJN4DANObsLzGO24tO2zz23Gqu94Ivwz5VRKpScY8ZKwML+kcwajUUCtRQAnbJLRYCdZBct5/aaqbRAvfDvxgUPOJsLppInNGP7zSuAZoWkjWkP3cRP1GVgELDY6++wYrNa4+z+qixsm5Is4Df1q/LV+v7xOGZGCL2nd2dIHGdwWbMf+0fNu/IU6i9hi/b6YpmdmTIUi/0Dda3UtquZlnrnmml5FsU+mo+ZykLVrKn0/B+3U6seKTI+vkYtM+qlcX0RwSk3/hudBP0Nj9doZ16NOelVP1r7u9V0MR1Xt6obHKLxYlk/f/Uvzmv/TfhbY8UMEK0HOSSa1SsO5fYwXG1qaOzdRbdrXCJS2yGpn8P8cyN/g5GElSg7KMVFTuvSJ94xmPB6uUm9iXUdepYwfX2YhCBU3wKJkzU1xlTTXBa/rbAYUZ3mY9Le1kaItz4Ce6mPuikFfoWSX6XYEZHAzZoGN1TikA+xGmRSnlOqHsEb1MymWuuWsyfI3Euwh6mlvLTqod2GkzJRt4fAqKyVN2GQCUM7maF2YP0BSGEcGN0+YAdYwrT3NTm3yqcnbXdcxUXeY48O+jm1ObUeH2X6Sz/XTZC/pp4xGNy7oQtHbNPhhcK2i4ZBZpgvjFO7qNN0Ke7HLY="
+  - secure: "hPkb8z84KYgPLy6uDSx3gcNgg2jxD6tlSS4nk3j3uEzz5QwJThglPUM1plerHrPFTqTDpZ5mOx+dWMxU6H81Yk2NZzV3JG2Ne0aSk69k6roD3LqGxPrbh3YpFr6go29QNgC971UuJJekM/RodBCE1Vjon4k+FkY1Ash2rKJrovFMhqP51NYqPysXxEDjJhYM7cLaJZV2SQ2jlPYXUAd5J4tgrCI1rOIa5gquiExIB868HDRF2GiFwqHqtYA/Y5npJMvpISvk70L3/6S9bqSw9vOvgFFMxmhKinrpDktN+Bm3kPWnNmx7pMrOFrQ46j6DoOViHpoGrqIDZbQoljCUst76oU82lHQZrkxTCx3bE9dc2atCg9NIWwTO4Pf31mjZ1uytNFNnqXK/UTwXUkJP908g5oDeB2JmbacFKJkPkTjc+diV96bm2YyLASzvKN1fT/7pftySRZ73Ngt2NSjdO62dx6xFZ6egP0P7vsEW+hrxPPjEfyjB2QEWr4EY7v1DZ47PU2mhbjFlaaA7sRuSQ5dO1vsyBz4s9OmsuihzlaxC1mYoOXrIItyD/+58Xyy3s6CpFqbSpaeQK5dFRNnhYeQh/rQIVYuj3CLk8SNIBPfTcnoGRq7rgWDQOlTS7Y0yyF7ZINIx5HmeTP9uLy28cO+8pbhj5Z2H09vDEO8ORwI="
+
+
 
 cache:
   directories:
@@ -48,7 +45,7 @@ cache:
 
 notifications:
   email:
+  - graeme.miller@cloudsoft.io
   - andrew.kennedy@cloudsoft.io
   - andrea.turli@cloudsoft.io
-  - graeme.miller@cloudsoft.io
   slack: clocker:YcGvQVVHfwIzEogvQJzY2Xvi

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -177,113 +177,48 @@
 
     <profiles>
         <profile>
-            <id>AcceptanceTest</id>
-            <activation>
-                <property>
-                    <name>Integration</name>
-                </property>
-            </activation>
+            <id>QA</id>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>build-helper-maven-plugin</artifactId>
-                        <version>1.9.1</version>
+                        <groupId>com.bazaarvoice.maven.plugins</groupId>
+                        <artifactId>s3-upload-maven-plugin</artifactId>
+                        <version>1.2</version>
                         <executions>
                             <execution>
-                                <id>reserve-brooklyn-port</id>
-                                <!-- Want a port to be reserved before resources are processed. -->
-                                <phase>initialize</phase>
+                                <phase>integration-test</phase>
                                 <goals>
-                                    <goal>reserve-network-port</goal>
+                                    <goal>s3-upload</goal>
                                 </goals>
                             </execution>
                         </executions>
                         <configuration>
-                            <portNames>
-                                <portName>brooklyn.console</portName>
-                            </portNames>
+                            <bucketName>clocker-latest</bucketName>
+                            <source>dist/target/brooklyn-clocker-dist.tar.gz</source>
                         </configuration>
                     </plugin>
+
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <version>1.3.2</version>
+                        <groupId>io.cloudsoft.amp</groupId>
+                        <artifactId>test-framework-maven-plugin</artifactId>
+                        <version>1.1-SNAPSHOT</version>
+                        <inherited>false</inherited>
                         <executions>
                             <execution>
-                                <id>run-brooklyn-server</id>
-                                <phase>pre-integration-test</phase>
-                                <goals><goal>exec</goal></goals>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>brooklyn-test</goal>
+                                </goals>
                                 <configuration>
-                                    <executable>${project.build.testOutputDirectory}/run-brooklyn.sh</executable>
-                                    <arguments>
-                                        <argument>${project.build.directory}/brooklyn-clocker-dist/brooklyn-clocker/bin/brooklyn.sh</argument>
-                                    </arguments>
+                                    <ampTestClusterUrl>http://169.50.81.105:8081</ampTestClusterUrl>
+                                    <locationFolderURI>${project.build.testOutputDirectory}/quality_assurance/locations</locationFolderURI>
+                                    <testAppFileURI>${project.build.testOutputDirectory}/quality_assurance/apps/nodejs_test.yaml</testAppFileURI>
+                                    <testSpecFileURI>${project.build.testOutputDirectory}/quality_assurance/combined_test.yaml</testSpecFileURI>
+                                    <noTearDownOnFailure>true</noTearDownOnFailure>
+                                    <verbose>false</verbose>
+                                    <maxTestDuration>80m</maxTestDuration>
+                                    <ampTestClusterUsername>brooklyn</ampTestClusterUsername>
                                 </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <!-- maven-resources-plugin does not preserve permissions when copying files. -->
-                    <!-- https://jira.codehaus.org/browse/MRESOURCES-132 -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <version>1.8</version>
-                        <executions>
-                            <execution>
-                                <id>fix-permissions-on-run.sh</id>
-                                <phase>process-test-resources</phase>
-                                <configuration>
-                                    <target>
-                                        <chmod file="target/test-classes/run-brooklyn.sh" perm="755"/>
-                                    </target>
-                                </configuration>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.18.1</version>
-                        <configuration>
-                            <parallel>methods</parallel>
-                            <threadCount>3</threadCount>
-                            <includes>
-                                <include>**/*IntegrationTest.java</include>
-                            </includes>
-                            <systemPropertyVariables>
-                                <brooklyn>http://localhost:${brooklyn.console}</brooklyn>
-                            </systemPropertyVariables>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>integration-tests</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>io.brooklyn.maven</groupId>
-                        <artifactId>brooklyn-maven-plugin</artifactId>
-                        <version>0.2.0-SNAPSHOT</version>
-                        <configuration>
-                            <server>http://localhost:${brooklyn.console}</server>
-                            <blueprint>${project.build.testOutputDirectory}/test-docker-cloud.yaml</blueprint>
-                            <!-- Fifteen minutes for slow clouds to provision. -->
-                            <timeout>15</timeout>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>deploy-docker-cloud</id>
-                                <goals>
-                                    <goal>deploy</goal>
-                                    <goal>stop-brooklyn</goal>
-                                </goals>
                             </execution>
                         </executions>
                     </plugin>
@@ -291,5 +226,4 @@
             </build>
         </profile>
     </profiles>
-
 </project>

--- a/dist/src/test/resources/quality_assurance/apps/nodejs_test.yaml
+++ b/dist/src/test/resources/quality_assurance/apps/nodejs_test.yaml
@@ -1,0 +1,30 @@
+brooklyn.catalog:
+  id: TestApp
+  version: 1.0
+  name: TestApp
+  itemType: template
+  item:
+    services:
+      #InfrastructureDeploymentTestCase will first setup the Infrastructure and then deploy an entity to it
+      - type: org.apache.brooklyn.test.framework.InfrastructureDeploymentTestCase
+        brooklyn.config:
+          infrastructure.deployment.location.sensor: entity.dynamicLocation
+          infrastructure.deployment.spec: $brooklyn:config("appToTest")
+          infrastructure.deployment.entity.specs:
+            - $brooklyn:entitySpec:
+              #UNDERNEATH HERE ARE THE INDIVIDUAL TESTS
+              - type: org.apache.brooklyn.test.framework.ParallelTestCase
+                brooklyn.children:
+                #TEST 1- Ensure that the nodejs-demo works as expected
+                - type: org.apache.brooklyn.test.framework.TestCase
+                  brooklyn.children:
+                    - type: "nodejs-demo-application:1.1.0-SNAPSHOT"
+                      id: nodejs-demo
+                      brooklyn.children:
+                    - type: org.apache.brooklyn.test.framework.TestSensor
+                      name: Check nodejs-demo isUp
+                      targetId: nodejs-demo
+                      sensor: service.isUp
+                      timeout: 1m
+                      assert:
+                       - equals: true

--- a/dist/src/test/resources/quality_assurance/combined_test.yaml
+++ b/dist/src/test/resources/quality_assurance/combined_test.yaml
@@ -1,0 +1,29 @@
+brooklyn.catalog:
+  id: test
+  version: 1.0
+  name: Test
+  itemType: template
+  item:
+    services:
+      - type: TestApp:1.0
+        brooklyn.config:
+          appToTest:
+            $brooklyn:entitySpec:
+              - type: docker-cloud:1.1.0-SNAPSHOT
+                id: infrastructure1
+                brooklyn.config:
+                  docker.host.cluster.initial.size: 2
+                  docker.registry.start: false
+                  docker.version: 1.7.1
+                  entity.dynamicLocation.name: ""
+      - type: TestApp:1.0
+        brooklyn.config:
+          appToTest:
+            $brooklyn:entitySpec:
+              - type: docker-cloud-calico:1.1.0-SNAPSHOT
+                id: infrastructure2
+                brooklyn.config:
+                  docker.host.cluster.initial.size: 2
+                  docker.registry.start: false
+                  docker.version: 1.7.1
+                  entity.dynamicLocation.name: ""

--- a/dist/src/test/resources/quality_assurance/deploy_sdn_app_test.yaml
+++ b/dist/src/test/resources/quality_assurance/deploy_sdn_app_test.yaml
@@ -1,0 +1,57 @@
+brooklyn.catalog:
+  id: sdn-test
+  version: 1.0
+  name: SDN Test
+  itemType: template
+  item:
+    services:
+      - type: org.apache.brooklyn.test.framework.InfrastructureDeploymentTestCase
+        brooklyn.config:
+          infrastructure.deployment.location.sensor: entity.dynamicLocation
+          infrastructure.deployment.spec:
+            $brooklyn:entitySpec:
+              - type: docker-cloud-calico
+                id: infrastructure
+                brooklyn.config:
+                  entity.dynamicLocation.name: my-docker-cloud
+                  docker.host.cluster.initial.size: 2
+                  docker.registry.start: false
+                  docker.version: 1.7.1
+          infrastructure.deployment.entity.specs:
+            - $brooklyn:entitySpec:
+                type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
+                id: TestServer
+                brooklyn.config:
+                  docker.container.directPorts:
+                    - 8080
+                launch.command: while true; do echo "hello world" | netcat -l 8080; done &
+                checkRunning.command: netcat localhost 8080
+            - $brooklyn:entitySpec:
+                type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
+                id: TestClient
+                launch.command: echo "There is no launch command!"
+                checkRunning.command: $brooklyn:formatString("netcat %s 8080", $brooklyn:component("TestServer").attributeWhenReady("host.subnet.hostname"))
+                brooklyn.config:
+                  start.timeout: 10m
+        brooklyn.children:
+          - type: org.apache.brooklyn.test.framework.TestSensor
+            name: Check infrastructure isUp
+            targetId: infrastructure
+            sensor: service.isUp
+            timeout: 20m
+            assert:
+             - equals: true
+          - type: org.apache.brooklyn.test.framework.TestSensor
+            name: Check TestClient isUp
+            targetId: TestClient
+            sensor: service.isUp
+            timeout: 20m
+            assert:
+             - equals: true
+          - type: org.apache.brooklyn.test.framework.TestSensor
+            name: Check TestServer isUp
+            targetId: TestServer
+            sensor: service.isUp
+            timeout: 20m
+            assert:
+             - equals: true

--- a/dist/src/test/resources/quality_assurance/deploy_simple_app_test.yaml
+++ b/dist/src/test/resources/quality_assurance/deploy_simple_app_test.yaml
@@ -1,0 +1,40 @@
+brooklyn.catalog:
+  id: simple-test
+  version: 1.0
+  name: Simple Test
+  itemType: template
+  item:
+    services:
+      - type: org.apache.brooklyn.test.framework.InfrastructureDeploymentTestCase
+        brooklyn.config:
+          infrastructure.deployment.location.sensor: entity.dynamicLocation
+          infrastructure.deployment.spec:
+            $brooklyn:entitySpec:
+              - type: brooklyn.entity.container.docker.DockerInfrastructure
+                id: infrastructure
+#                location: named:softlayer-sea01
+                brooklyn.config:
+                  docker.addLocalhostPermission: true
+                  entity.dynamicLocation.name: my-docker-cloud
+                  docker.host.cluster.initial.size: 1
+                  docker.registry.start: false
+                  docker.version: 1.7.1
+          infrastructure.deployment.entity.specs:
+            - $brooklyn:entitySpec:
+                - type: org.apache.brooklyn.entity.webapp.jboss.JBoss7Server
+                  id: JBoss7Server
+        brooklyn.children:
+          - type: org.apache.brooklyn.test.framework.TestSensor
+            name: Check infrastructure isUp
+            targetId: infrastructure
+            sensor: service.isUp
+            timeout: 10m
+            assert:
+             - equals: true
+          - type: org.apache.brooklyn.test.framework.TestSensor
+            name: Check JBoss isUp
+            targetId: JBoss7Server
+            sensor: service.isUp
+            timeout: 10m
+            assert:
+             - equals: true

--- a/dist/src/test/resources/quality_assurance/infrastructure_test.yaml
+++ b/dist/src/test/resources/quality_assurance/infrastructure_test.yaml
@@ -1,0 +1,64 @@
+services:
+  - type: org.apache.brooklyn.test.framework.TestCase
+    brooklyn.children:
+      - type: brooklyn.entity.container.docker.DockerInfrastructure
+        location: named:aws-california
+        id: infrastructure
+        brooklyn.config:
+          entity.dynamicLocation.name: my-docker-cloud
+          docker.host.cluster.initial.size: 2
+          docker.registry.start: false
+          docker.version: 1.7.1
+      - type: org.apache.brooklyn.test.framework.TestSensor
+        name: Check infrastructure isUp
+        sensor: service.isUp
+        targetId: infrastructure
+        timeout: 1m
+        assert:
+         - equals: true
+      - type: org.apache.brooklyn.test.framework.LoopOverGroupMembersTestCase
+        target: $brooklyn:component("infrastructure").component("child", "DockerHosts")
+        testSpec:
+          $brooklyn:entitySpec:
+            type: org.apache.brooklyn.test.framework.TestCase
+            brooklyn.children:
+              # Check that the hosts itself is up and running as expected
+              - type: org.apache.brooklyn.test.framework.ParallelTestCase
+                brooklyn.children:
+                  - type: org.apache.brooklyn.test.framework.TestSensor
+                    name: Check DockerHost isUp
+                    sensor: service.isUp
+                    timeout: 1m
+                    assert:
+                     - equals: true
+                  - type: org.apache.brooklyn.test.framework.TestEffector
+                    name: Check DockerHost runDockerCommand effector
+                    effector: runDockerCommand
+                    timeout: 1m
+                    params:
+                      command: info
+                    assert:
+                     - contains: "Containers: 0"
+              # Test deploying and undeploying with an effector
+              - type: org.apache.brooklyn.test.framework.TestCase
+                brooklyn.children:
+                 - type: org.apache.brooklyn.test.framework.TestEffector
+                   name: Deploy test entity
+                   effector: runDockerCommand
+                   timeout: 10m
+                   params:
+                     command: run -d elasticsearch
+                 - type: org.apache.brooklyn.test.framework.TestEffector
+                   name: ensure docker info thinks there are containers
+                   effector: runDockerCommand
+                   timeout: 1m
+                   params:
+                     command: info
+                   assert:
+                    - contains: "Containers: 1"
+                 - type: org.apache.brooklyn.test.framework.TestSensor
+                   name: Check containers total
+                   sensor: docker.containers.total
+                   timeout: 1m
+                   assert:
+                    - equals: 1

--- a/dist/src/test/resources/quality_assurance/locations/test_location_aws_cali.yaml
+++ b/dist/src/test/resources/quality_assurance/locations/test_location_aws_cali.yaml
@@ -1,0 +1,9 @@
+brooklyn.catalog:
+  id: cal
+  version: 1.0
+  itemType: location
+  name: cal
+  item:
+    type: jclouds:aws-ec2:us-west-2
+    brooklyn.config:
+     osFamily: ubuntu

--- a/dist/src/test/resources/quality_assurance/locations/test_location_softlayer.yaml
+++ b/dist/src/test/resources/quality_assurance/locations/test_location_softlayer.yaml
@@ -1,0 +1,7 @@
+brooklyn.catalog:
+  id: soft
+  version: 1.0
+  itemType: location
+  name: soft
+  item:
+    type: jclouds:softlayer:sea01

--- a/dist/src/test/resources/quality_assurance/test_app.yaml
+++ b/dist/src/test/resources/quality_assurance/test_app.yaml
@@ -1,0 +1,15 @@
+brooklyn.catalog:
+  id: simple-test-app
+  version: 1.0
+  itemType: template
+  name: Simple Test App
+  license: Apache-2.0
+  item:
+    services:
+      - type: "docker-cloud:1.1.0-SNAPSHOT"
+        id: infrastructure1
+        brooklyn.config:
+          entity.dynamicLocation.name: my-docker-cloud
+          docker.host.cluster.initial.size: 2
+          docker.registry.start: false
+          docker.version: 1.7.1

--- a/dist/src/test/resources/quality_assurance/very_basic_test.yaml
+++ b/dist/src/test/resources/quality_assurance/very_basic_test.yaml
@@ -1,0 +1,43 @@
+brooklyn.catalog:
+  id: simple-test
+  version: 1.0
+  name: Simple Test
+  itemType: template
+  item:
+    services:
+      - type: org.apache.brooklyn.test.framework.InfrastructureDeploymentTestCase
+        brooklyn.config:
+          infrastructure.deployment.location.sensor: entity.dynamicLocation
+          infrastructure.deployment.spec:
+            $brooklyn:entitySpec:
+              - type: brooklyn.entity.container.docker.DockerInfrastructure
+                id: infrastructure
+                brooklyn.config:
+                  docker.addLocalhostPermission: true
+                  docker.host.cluster.initial.size: 1
+                  docker.registry.start: false
+                  docker.version: 1.7.1
+          infrastructure.deployment.entity.specs:
+            - $brooklyn:entitySpec:
+                type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
+                id: TestServer
+                brooklyn.config:
+                  docker.container.directPorts:
+                    - 8080
+                launch.command: while true; do echo "hello world" | nc -l 8080; done &
+                checkRunning.command: echo 'up'
+        brooklyn.children:
+          - type: org.apache.brooklyn.test.framework.TestSensor
+            name: Check infrastructure isUp
+            targetId: infrastructure
+            sensor: service.isUp
+            timeout: 10m
+            assert:
+             - equals: true
+          - type: org.apache.brooklyn.test.framework.TestSensor
+            name: Check TestServer isUp
+            targetId: TestServer
+            sensor: service.isUp
+            timeout: 20m
+            assert:
+             - equals: true

--- a/dist/src/test/resources/test_location.yaml
+++ b/dist/src/test/resources/test_location.yaml
@@ -1,0 +1,7 @@
+brooklyn.catalog:
+  id: cal1
+  version: 1.0
+  itemType: location
+  name: cal1
+  item:
+    type: localhost

--- a/dist/src/test/resources/travis_maven_settings.xml
+++ b/dist/src/test/resources/travis_maven_settings.xml
@@ -1,0 +1,56 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <profiles>
+        <profile>
+            <id>QA</id>
+            <pluginRepositories>
+                <pluginRepository>
+                    <snapshots />
+                    <id>cloudsoft-snapshots</id>
+                    <name>cloudsoft-snapshots</name>
+                    <url>https://artifactory.cloudsoftcorp.com/artifactory/libs-snapshot-local</url>
+                </pluginRepository>
+            </pluginRepositories>
+            <repositories>
+                <repository>
+                    <id>cloudsoft-releases</id>
+                    <url>http://artifactory.cloudsoftcorp.com/artifactory/libs-release-local/</url>
+                </repository>
+                <repository>
+                    <id>cloudsoft-snapshots</id>
+                    <url>https://artifactory.cloudsoftcorp.com/artifactory/libs-snapshot-local/</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+                <repository>
+                    <id>sonatype-nexus-snapshots</id>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+
+                <!-- enable apache snapshots repo (only for snapshots) -->
+                <repository>
+                    <id>apache-snapshots</id>
+                    <url>https://repository.apache.org/content/repositories/snapshots</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
+</settings>

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerHostImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerHostImpl.java
@@ -64,6 +64,7 @@ import org.apache.brooklyn.api.location.PortRange;
 import org.apache.brooklyn.api.mgmt.LocationManager;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.policy.PolicySpec;
+import org.apache.brooklyn.camp.brooklyn.BrooklynCampConstants;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.render.RendererHints;
 import org.apache.brooklyn.core.effector.ssh.SshEffectorTasks;
@@ -176,6 +177,7 @@ public class DockerHostImpl extends MachineEntityImpl implements DockerHost {
         Group containers = addChild(EntitySpec.create(BasicGroup.class)
                 .configure(BasicGroup.RUNNING_QUORUM_CHECK, QuorumChecks.atLeastOneUnlessEmpty())
                 .configure(BasicGroup.UP_QUORUM_CHECK, QuorumChecks.atLeastOneUnlessEmpty())
+                .configure(BrooklynCampConstants.PLAN_ID, "docker-host-containers")
                 .displayName("Docker Containers"));
         if (config().get(DockerInfrastructure.HA_POLICY_ENABLE)) {
             containers.policies().add(PolicySpec.create(ServiceReplacer.class)

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerInfrastructure.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerInfrastructure.java
@@ -32,6 +32,7 @@ import org.apache.brooklyn.core.entity.StartableApplication;
 import org.apache.brooklyn.core.entity.trait.Resizable;
 import org.apache.brooklyn.core.location.dynamic.LocationOwner;
 import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
+import org.apache.brooklyn.core.sensor.BasicAttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.entity.group.DynamicCluster;
 import org.apache.brooklyn.entity.group.DynamicGroup;
@@ -57,7 +58,7 @@ public interface DockerInfrastructure extends StartableApplication, Resizable, L
 
     @CatalogConfig(label = "Location Name", priority = 90)
     @SetFromFlag("locationName")
-    AttributeSensorAndConfigKey<String, String> LOCATION_NAME = ConfigKeys.newSensorAndConfigKeyWithDefault(LocationOwner.LOCATION_NAME, "my-docker-cloud");
+    BasicAttributeSensorAndConfigKey<String> LOCATION_NAME = LocationOwner.LOCATION_NAME;
 
     @CatalogConfig(label = "Docker Version", priority = 10)
     @SetFromFlag("dockerVersion")

--- a/docker/src/main/java/brooklyn/entity/container/docker/DockerInfrastructureImpl.java
+++ b/docker/src/main/java/brooklyn/entity/container/docker/DockerInfrastructureImpl.java
@@ -54,6 +54,7 @@ import org.apache.brooklyn.api.mgmt.LocationManager;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.policy.PolicySpec;
 import org.apache.brooklyn.api.sensor.EnricherSpec;
+import org.apache.brooklyn.camp.brooklyn.BrooklynCampConstants;
 import org.apache.brooklyn.core.config.render.RendererHints;
 import org.apache.brooklyn.core.entity.AbstractApplication;
 import org.apache.brooklyn.core.entity.Attributes;
@@ -100,6 +101,8 @@ public class DockerInfrastructureImpl extends AbstractApplication implements Doc
     private static final Logger LOG = LoggerFactory.getLogger(DockerInfrastructure.class);
 
     private transient Object mutex = new Object[0];
+
+    private static final AtomicInteger infrastructureID = new AtomicInteger();
 
     @Override
     public Object getInfrastructureMutex() {
@@ -162,6 +165,7 @@ public class DockerInfrastructureImpl extends AbstractApplication implements Doc
                 .configure(DynamicCluster.MEMBER_SPEC, dockerHostSpec)
                 .configure(DynamicCluster.RUNNING_QUORUM_CHECK, QuorumChecks.atLeastOneUnlessEmpty())
                 .configure(DynamicCluster.UP_QUORUM_CHECK, QuorumChecks.atLeastOneUnlessEmpty())
+                .configure(BrooklynCampConstants.PLAN_ID, "docker-hosts")
                 .displayName("Docker Hosts"));
 
         DynamicGroup fabric = addChild(EntitySpec.create(DynamicGroup.class)
@@ -310,7 +314,7 @@ public class DockerInfrastructureImpl extends AbstractApplication implements Doc
         if (Strings.isBlank(locationName)) {
             String prefix = config().get(LOCATION_NAME_PREFIX);
             String suffix = config().get(LOCATION_NAME_SUFFIX);
-            locationName = Joiner.on("-").skipNulls().join(prefix, getId(), suffix);
+            locationName = Joiner.on("-").skipNulls().join(prefix, getId(), suffix, infrastructureID.incrementAndGet());
         }
         LocationDefinition check = getManagementContext().getLocationRegistry().getDefinedLocationByName(locationName);
         if (check != null) {


### PR DESCRIPTION
Added Automatic QA. There is a new profile in the Clocker dist maven that will upload the dist to AWS, and then kickoff a test run using the QA framework.

I have also included travis configuration to do this automatically.

I have made a couple of changes to core Clocker code. Namely:
- Added some PLAN_IDs. This is to allow these components to be reference by test entities
- Removed 'my-docker-cloud' default location name. Need to add multiple infrastructures without setting the name for testing. Infrastructures will now be give a name with an auto incremented ID added