### PR TITLE
fix npe when no public address for MarathonTaskLocation.targetMachine

### DIFF
--- a/mesos/src/main/java/brooklyn/entity/mesos/framework/marathon/MarathonPortForwarder.java
+++ b/mesos/src/main/java/brooklyn/entity/mesos/framework/marathon/MarathonPortForwarder.java
@@ -18,6 +18,7 @@ package brooklyn.entity.mesos.framework.marathon;
 import java.util.List;
 import java.util.Map;
 
+import brooklyn.location.mesos.framework.marathon.MarathonTaskLocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -149,7 +150,7 @@ public class MarathonPortForwarder implements PortForwarder {
             publicSide = HostAndPort.fromParts(marathonHostname, targetPort);
         }
         pfw.associate(marathonHostname, publicSide, (Location) targetMachine, targetPort);
-        portmap.put(publicSide, HostAndPort.fromParts(targetMachine.getHostname(), targetPort));
+        portmap.put(publicSide, HostAndPort.fromParts(((MarathonTaskLocation) targetMachine).getSubnetHostname(), targetPort));
         return publicSide;
     }
 


### PR DESCRIPTION
Fixes the issue raised in #264, have tested in Blue Box VPN in both a publically accessible cluster and one accessible only via VPN.

@grkvlt I don't have a solid grasp on the handling of hostnames in this case so suspect this may be too simplistic a fix.