### PR TITLE
pull security group from location (requires #272)

### DIFF
--- a/dist/src/main/assembly/conf/brooklyn/default.catalog.bom
+++ b/dist/src/main/assembly/conf/brooklyn/default.catalog.bom
@@ -30,11 +30,11 @@ brooklyn.catalog:
         docker.policy.ha.enable: false
         docker.container.strategies:
         - $brooklyn:object:
-            type: clocker.docker.location.strategy.MaxContainersPlacementStrategy
+            type: clocker.docker.location.strategy.basic.MaxContainersPlacementStrategy
             brooklyn.config:
               maxContainers: 16
         - $brooklyn:object:
-            type: clocker.docker.location.strategy.BreadthFirstPlacementStrategy
+            type: clocker.docker.location.strategy.basic.BreadthFirstPlacementStrategy
         docker.host.spec:
           $brooklyn:entitySpec:
             type: docker-host
@@ -152,11 +152,11 @@ brooklyn.catalog:
           docker.container.cluster.headroom.count: 0
           docker.container.strategies:
           - $brooklyn:object:
-              type: clocker.docker.location.strategy.MaxContainersPlacementStrategy
+              type: clocker.docker.location.strategy.basic.MaxContainersPlacementStrategy
               brooklyn.config:
                 maxContainers: 32
           - $brooklyn:object:
-              type: clocker.docker.location.strategy.DepthFirstPlacementStrategy
+              type: clocker.docker.location.strategy.basic.DepthFirstPlacementStrategy
           sdn.enable: false
 
   - id: docker-cloud-calico

--- a/dist/src/main/assembly/conf/logback.xml
+++ b/dist/src/main/assembly/conf/logback.xml
@@ -16,7 +16,9 @@
 -->
 <configuration>
     <property name="logging.basename" scope="context" value="brooklyn-clocker" />
-    <logger name="brooklyn.clocker" level="DEBUG" />
+
+    <logger name="clocker" level="DEBUG" />
+
     <include resource="logback-main.xml" />
     <include resource="brooklyn/logback-logger-debug-jclouds.xml" />
 </configuration>

--- a/dist/src/main/assembly/files/blueprints/docker-localhost.yaml
+++ b/dist/src/main/assembly/files/blueprints/docker-localhost.yaml
@@ -27,5 +27,5 @@ services:
     install.skip: true
     docker.container.strategies:
     - $brooklyn:object:
-        type: clocker.docker.location.strategy.DepthFirstPlacementStrategy
+        type: clocker.docker.location.strategy.basic.DepthFirstPlacementStrategy
     docker.container.nameFormat: "container-%2$02x"

--- a/dist/src/main/assembly/files/blueprints/nodejs-todo.yaml
+++ b/dist/src/main/assembly/files/blueprints/nodejs-todo.yaml
@@ -26,7 +26,7 @@ services:
     install.version: 3.0.0
     docker.container.strategies:
     - $brooklyn:object:
-        type: "clocker.docker.location.strategy.ProvisioningFlagsPlacementStrategy"
+        type: "clocker.docker.location.strategy.host.ProvisioningFlagsPlacementStrategy"
         brooklyn.config:
           minRam: 4000
 
@@ -38,7 +38,7 @@ services:
     - "http.port"
     docker.container.strategies:
     - $brooklyn:object:
-        type: "clocker.docker.location.strategy.ProvisioningFlagsPlacementStrategy"
+        type: "clocker.docker.location.strategy.host.ProvisioningFlagsPlacementStrategy"
         brooklyn.config:
           minRam: 1000
     gitRepoUrl:

--- a/dist/src/main/assembly/files/blueprints/redis-label-placement.yaml
+++ b/dist/src/main/assembly/files/blueprints/redis-label-placement.yaml
@@ -29,7 +29,7 @@ services:
     install.version: 3.0.0
     docker.container.strategies:
     - $brooklyn:object:
-        type: "clocker.docker.location.strategy.LabelPlacementStrategy"
+        type: "clocker.docker.location.strategy.basic.LabelPlacementStrategy"
         brooklyn.config:
           docker.constraint.labels:
           - "ssd"

--- a/docker/src/main/java/clocker/docker/entity/DockerHost.java
+++ b/docker/src/main/java/clocker/docker/entity/DockerHost.java
@@ -133,7 +133,7 @@ public interface DockerHost extends MachineEntity, HasShortName, LocationOwner<D
 
     @SetFromFlag("scanInterval")
     ConfigKey<Duration> SCAN_INTERVAL = ConfigKeys.newConfigKey(Duration.class,
-            "docker.host.scanInterval", "Interval between scans of Docker containers", Duration.TEN_SECONDS);
+            "docker.host.scanInterval", "Interval between scans of Docker containers", Duration.THIRTY_SECONDS);
     AttributeSensor<Void> SCAN = Sensors.newSensor(Void.class, "docker.host.scan", "Notification of host scan");
 
     AttributeSensor<Group> DOCKER_CONTAINER_CLUSTER = Sensors.newSensor(Group.class,

--- a/docker/src/main/java/clocker/docker/entity/DockerHostImpl.java
+++ b/docker/src/main/java/clocker/docker/entity/DockerHostImpl.java
@@ -882,8 +882,8 @@ public class DockerHostImpl extends MachineEntityImpl implements DockerHost {
         //TODO change to HttpFeed with client certificates at some point in the future
         serviceUpIsRunningFeed = SshFeed.builder()
                 .entity(this)
-                .period(Duration.FIVE_SECONDS)
-                .machine(this.getMachine())
+                .period(Duration.THIRTY_SECONDS)
+                .machine(getMachine())
                 .poll(new SshPollConfig<Boolean>(SERVICE_UP)
                         .command("docker ps")
                         .onSuccess(Functions.constant(true))

--- a/docker/src/main/java/clocker/docker/entity/DockerHostSshDriver.java
+++ b/docker/src/main/java/clocker/docker/entity/DockerHostSshDriver.java
@@ -38,13 +38,10 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
-import org.jclouds.compute.strategy.GetNodeMetadataStrategy;
-
 import org.apache.brooklyn.api.location.OsDetails;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.core.effector.ssh.SshEffectorTasks;
 import org.apache.brooklyn.core.entity.Attributes;
-import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.entity.group.AbstractGroup;
 import org.apache.brooklyn.entity.group.DynamicGroup;
 import org.apache.brooklyn.entity.software.base.AbstractSoftwareProcessSshDriver;

--- a/docker/src/main/java/clocker/docker/entity/DockerHostSshDriver.java
+++ b/docker/src/main/java/clocker/docker/entity/DockerHostSshDriver.java
@@ -27,6 +27,7 @@ import static org.apache.brooklyn.util.ssh.BashCommands.ifExecutableElse1;
 import static org.apache.brooklyn.util.ssh.BashCommands.installPackage;
 import static org.apache.brooklyn.util.ssh.BashCommands.sudo;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -46,6 +47,7 @@ import org.apache.brooklyn.entity.group.AbstractGroup;
 import org.apache.brooklyn.entity.group.DynamicGroup;
 import org.apache.brooklyn.entity.software.base.AbstractSoftwareProcessSshDriver;
 import org.apache.brooklyn.entity.software.base.lifecycle.ScriptHelper;
+import org.apache.brooklyn.location.jclouds.JcloudsLocationConfig;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -261,6 +263,13 @@ public class DockerHostSshDriver extends AbstractSoftwareProcessSshDriver implem
         if (!result) {
             throw new IllegalStateException(String.format("The entity %s is not sshable after reboot (waited %s)",
                     entity, Time.makeTimeStringRounded(stopwatchForReboot)));
+        }
+        if (entity.config().get(JcloudsLocationConfig.MAP_DEV_RANDOM_TO_DEV_URANDOM)) {
+            newScript(INSTALLING + "urandom")
+            .body.append(
+                    sudo("mv /dev/random /dev/random-real"),
+                    sudo("ln -s /dev/urandom /dev/random"))
+            .execute();
         }
     }
 

--- a/docker/src/main/java/clocker/docker/entity/DockerInfrastructure.java
+++ b/docker/src/main/java/clocker/docker/entity/DockerInfrastructure.java
@@ -22,9 +22,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import clocker.docker.entity.util.DockerAttributes;
 import clocker.docker.entity.util.DockerUtils;
 import clocker.docker.location.DockerLocation;
-import clocker.docker.location.strategy.DepthFirstPlacementStrategy;
 import clocker.docker.location.strategy.DockerAwarePlacementStrategy;
 import clocker.docker.location.strategy.affinity.AffinityRules;
+import clocker.docker.location.strategy.basic.DepthFirstPlacementStrategy;
 import clocker.docker.networking.entity.sdn.util.SdnAttributes;
 
 import com.google.common.reflect.TypeToken;

--- a/docker/src/main/java/clocker/docker/entity/SaveHostnameCustomizer.java
+++ b/docker/src/main/java/clocker/docker/entity/SaveHostnameCustomizer.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package clocker.docker.entity;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import org.jclouds.compute.ComputeService;
+import org.jclouds.compute.domain.Template;
+import org.jclouds.softlayer.compute.options.SoftLayerTemplateOptions;
+
+import org.apache.brooklyn.core.effector.ssh.SshEffectorTasks;
+import org.apache.brooklyn.location.jclouds.BasicJcloudsLocationCustomizer;
+import org.apache.brooklyn.location.jclouds.JcloudsLocation;
+import org.apache.brooklyn.location.jclouds.JcloudsMachineLocation;
+import org.apache.brooklyn.location.jclouds.JcloudsSshMachineLocation;
+import org.apache.brooklyn.util.core.task.DynamicTasks;
+import org.apache.brooklyn.util.ssh.BashCommands;
+
+/**
+ * Saves the hostname as the jclouds machine name.
+ */
+public class SaveHostnameCustomizer extends BasicJcloudsLocationCustomizer {
+
+    public static final Logger LOG = LoggerFactory.getLogger(SaveHostnameCustomizer.class);
+
+    public static SaveHostnameCustomizer instanceOf() {
+        return new SaveHostnameCustomizer();
+    }
+
+    @Override
+    public void customize(JcloudsLocation location, ComputeService computeService, Template template) {
+        SoftLayerTemplateOptions options = (SoftLayerTemplateOptions) template.getOptions();
+        String name = options.getUserMetadata().get("Name");
+        options.nodeNames(ImmutableSet.of(name));
+    }
+
+    @Override
+    public void customize(JcloudsLocation location, ComputeService computeService, JcloudsMachineLocation machine) {
+        JcloudsSshMachineLocation ssh = (JcloudsSshMachineLocation) machine;
+        String name = ssh.getHostname();
+
+        List<String> commands = ImmutableList.of(
+                BashCommands.sudo(String.format("hostname %s", name)),
+                String.format("echo %s | ( %s )", name, BashCommands.sudo("tee /etc/hostname")),
+                BashCommands.sudo("sed -i \"/(none)/d\" /etc/hosts"));
+        DynamicTasks.queue(SshEffectorTasks.ssh(commands)
+                .machine(ssh)
+                .requiringExitCodeZero()).block();
+        LOG.debug("Set {} hostname to {}", new Object[] { ssh, name });
+    }
+}

--- a/docker/src/main/java/clocker/docker/entity/container/DockerContainer.java
+++ b/docker/src/main/java/clocker/docker/entity/container/DockerContainer.java
@@ -107,6 +107,9 @@ public interface DockerContainer extends BasicStartable, HasNetworkAddresses, Ha
     @SetFromFlag("volumes")
     ConfigKey<List<String>> DOCKER_CONTAINER_VOLUME_EXPORT = DockerAttributes.DOCKER_CONTAINER_VOLUME_EXPORT;
 
+    @SetFromFlag("volumesFrom")
+    ConfigKey<List<String>> DOCKER_CONTAINER_VOLUMES_FROM = DockerAttributes.DOCKER_CONTAINER_VOLUMES_FROM;
+
     @SetFromFlag("env")
     AttributeSensorAndConfigKey<Map<String, Object>, Map<String, Object>> DOCKER_CONTAINER_ENVIRONMENT = ConfigKeys.newSensorAndConfigKey(
             new TypeToken<Map<String, Object>>() { },

--- a/docker/src/main/java/clocker/docker/entity/container/DockerContainer.java
+++ b/docker/src/main/java/clocker/docker/entity/container/DockerContainer.java
@@ -86,6 +86,9 @@ public interface DockerContainer extends BasicStartable, HasNetworkAddresses, Ha
     @SetFromFlag("entrypoint")
     ConfigKey<List<String>> DOCKER_IMAGE_ENTRYPOINT = DockerAttributes.DOCKER_IMAGE_ENTRYPOINT.getConfigKey();
 
+    @SetFromFlag("commands")
+    ConfigKey<List<String>> DOCKER_IMAGE_COMMANDS = DockerAttributes.DOCKER_IMAGE_COMMANDS.getConfigKey();
+
     @SetFromFlag("hardwareId")
     ConfigKey<String> DOCKER_HARDWARE_ID = DockerAttributes.DOCKER_HARDWARE_ID.getConfigKey();
 

--- a/docker/src/main/java/clocker/docker/entity/container/DockerContainerImpl.java
+++ b/docker/src/main/java/clocker/docker/entity/container/DockerContainerImpl.java
@@ -260,7 +260,7 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
     private void removeContainer() {
         final String dockerContainerName = sensors().get(DockerContainer.DOCKER_CONTAINER_NAME);
         LOG.info("Removing {}", dockerContainerName);
-        getDockerHost().runDockerCommand("rm " + getContainerId());
+        getDockerHost().runDockerCommand("rm " + dockerContainerName);
     }
 
     private DockerTemplateOptions getDockerTemplateOptions() {
@@ -677,7 +677,9 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
         }
 
         // Stop and remove the Docker container running on the host
-        shutDown();
+        if (getContainerId() != null) {
+            shutDown();
+        }
         removeContainer();
 
         sensors().set(SSH_MACHINE_LOCATION, null);

--- a/docker/src/main/java/clocker/docker/entity/container/DockerContainerImpl.java
+++ b/docker/src/main/java/clocker/docker/entity/container/DockerContainerImpl.java
@@ -69,6 +69,7 @@ import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
+import org.apache.brooklyn.core.entity.trait.StartableMethods;
 import org.apache.brooklyn.core.feed.ConfigToAttributes;
 import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
@@ -667,6 +668,13 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
         if (status == null) {
             connectSensors();
         }
+    }
+
+    @Override
+    public void restart() {
+        StartableMethods.stop(this);
+
+        super.restart();
     }
 
     @Override

--- a/docker/src/main/java/clocker/docker/entity/container/DockerContainerImpl.java
+++ b/docker/src/main/java/clocker/docker/entity/container/DockerContainerImpl.java
@@ -420,12 +420,19 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
         }
         options.env(env);
 
-        // Entrypoint
+        // Entrypoint and commands
+        // TODO parse string into list?
         List<String> entrypoint = entity.config().get(DockerContainer.DOCKER_IMAGE_ENTRYPOINT);
         if (entrypoint != null && entrypoint.size() > 0) {
             options.entrypoint(entrypoint);
             sensors().set(DockerAttributes.DOCKER_IMAGE_ENTRYPOINT, entrypoint);
             entity.sensors().set(DockerAttributes.DOCKER_IMAGE_ENTRYPOINT, entrypoint);
+        }
+        List<String> commands = entity.config().get(DockerContainer.DOCKER_IMAGE_COMMANDS);
+        if (commands != null && commands.size() > 0) {
+            options.commands(commands);
+            sensors().set(DockerAttributes.DOCKER_IMAGE_COMMANDS, commands);
+            entity.sensors().set(DockerAttributes.DOCKER_IMAGE_COMMANDS, commands);
         }
 
         // Log for debugging without password
@@ -577,6 +584,7 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
             LocationSpec<DockerContainerLocation> spec = LocationSpec.create(DockerContainerLocation.class);
             spec.configure(flags)
                 .configure(DynamicLocation.OWNER, this)
+                .configure("entity", entity)
                 .configure("machine", container) // the underlying JcloudsLocation
                 .configure(container.config().getBag().getAllConfig())
                 .configure("address", getSshHostAddress())

--- a/docker/src/main/java/clocker/docker/entity/container/DockerContainerImpl.java
+++ b/docker/src/main/java/clocker/docker/entity/container/DockerContainerImpl.java
@@ -351,6 +351,10 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
         sensors().set(DockerAttributes.DOCKER_VOLUME_MAPPING, volumes);
         entity.sensors().set(DockerAttributes.DOCKER_VOLUME_MAPPING, volumes);
         options.volumes(volumes);
+        List<String> imports = entity.config().get(DockerContainer.DOCKER_CONTAINER_VOLUMES_FROM);
+        if (imports != null) {
+            options.volumesFrom(imports);
+        }
 
         // Direct port mappings
         Map<Integer, Integer> bindings = MutableMap.copyOf(entity.config().get(DockerAttributes.DOCKER_PORT_BINDINGS));

--- a/docker/src/main/java/clocker/docker/entity/container/DockerContainerImpl.java
+++ b/docker/src/main/java/clocker/docker/entity/container/DockerContainerImpl.java
@@ -258,7 +258,7 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
      * Should only be called when the container is not running.
      */
     private void removeContainer() {
-        final String dockerContainerName = sensors().get(DockerContainer.DOCKER_CONTAINER_NAME);
+        String dockerContainerName = sensors().get(DockerContainer.DOCKER_CONTAINER_NAME);
         LOG.info("Removing {}", dockerContainerName);
         getDockerHost().runDockerCommand("rm " + dockerContainerName);
     }

--- a/docker/src/main/java/clocker/docker/entity/container/application/VanillaDockerApplication.java
+++ b/docker/src/main/java/clocker/docker/entity/container/application/VanillaDockerApplication.java
@@ -89,6 +89,8 @@ public interface VanillaDockerApplication extends VanillaSoftwareProcess {
 
     ConfigKey<Boolean> SKIP_ENTITY_INSTALLATION = ConfigKeys.newConfigKeyWithDefault(BrooklynConfigKeys.SKIP_ENTITY_INSTALLATION, Boolean.TRUE);
 
+    ConfigKey<String> ON_BOX_BASE_DIR = ConfigKeys.newConfigKeyWithDefault(BrooklynConfigKeys.ONBOX_BASE_DIR, "/tmp/clocker");
+
     ConfigKey<Boolean> SKIP_ON_BOX_BASE_DIR_RESOLUTION = ConfigKeys.newConfigKeyWithDefault(BrooklynConfigKeys.SKIP_ON_BOX_BASE_DIR_RESOLUTION, Boolean.TRUE);
 
     ConfigKey<String> LAUNCH_COMMAND = ConfigKeys.newConfigKeyWithDefault(VanillaSoftwareProcess.LAUNCH_COMMAND, null);

--- a/docker/src/main/java/clocker/docker/entity/container/application/VanillaDockerApplication.java
+++ b/docker/src/main/java/clocker/docker/entity/container/application/VanillaDockerApplication.java
@@ -88,7 +88,7 @@ public interface VanillaDockerApplication extends VanillaSoftwareProcess {
     ConfigKey<List<Entity>> DOCKER_LINKS = DockerAttributes.DOCKER_LINKS;
 
     ConfigKey<Boolean> SKIP_ENTITY_INSTALLATION = ConfigKeys.newConfigKeyWithDefault(BrooklynConfigKeys.SKIP_ENTITY_INSTALLATION, Boolean.TRUE);
-    
+
     ConfigKey<Boolean> SKIP_ON_BOX_BASE_DIR_RESOLUTION = ConfigKeys.newConfigKeyWithDefault(BrooklynConfigKeys.SKIP_ON_BOX_BASE_DIR_RESOLUTION, Boolean.TRUE);
 
     ConfigKey<String> LAUNCH_COMMAND = ConfigKeys.newConfigKeyWithDefault(VanillaSoftwareProcess.LAUNCH_COMMAND, null);

--- a/docker/src/main/java/clocker/docker/entity/container/application/VanillaDockerApplication.java
+++ b/docker/src/main/java/clocker/docker/entity/container/application/VanillaDockerApplication.java
@@ -57,6 +57,9 @@ public interface VanillaDockerApplication extends VanillaSoftwareProcess {
     @SetFromFlag("entrypoint")
     ConfigKey<List<String>> IMAGE_ENTRYPOINT = DockerAttributes.DOCKER_IMAGE_ENTRYPOINT.getConfigKey();
 
+    @SetFromFlag("commands")
+    ConfigKey<List<String>> IMAGE_COMMANDS = DockerAttributes.DOCKER_IMAGE_COMMANDS.getConfigKey();
+
     @SetFromFlag("useSsh")
     ConfigKey<Boolean> DOCKER_USE_SSH = ConfigKeys.newConfigKeyWithDefault(DockerAttributes.DOCKER_USE_SSH, Boolean.FALSE);
 

--- a/docker/src/main/java/clocker/docker/entity/container/application/VanillaDockerApplication.java
+++ b/docker/src/main/java/clocker/docker/entity/container/application/VanillaDockerApplication.java
@@ -78,6 +78,9 @@ public interface VanillaDockerApplication extends VanillaSoftwareProcess {
     @SetFromFlag("volumes")
     ConfigKey<List<String>> DOCKER_CONTAINER_VOLUME_EXPORT = DockerAttributes.DOCKER_CONTAINER_VOLUME_EXPORT;
 
+    @SetFromFlag("volumesFrom")
+    ConfigKey<List<String>> DOCKER_CONTAINER_VOLUMES_FROM = DockerAttributes.DOCKER_CONTAINER_VOLUMES_FROM;
+
     @SetFromFlag("volumeMappings")
     AttributeSensorAndConfigKey<Map<String, String>, Map<String, String>> DOCKER_HOST_VOLUME_MAPPING = DockerAttributes.DOCKER_HOST_VOLUME_MAPPING;
 

--- a/docker/src/main/java/clocker/docker/entity/container/application/VanillaDockerApplicationImpl.java
+++ b/docker/src/main/java/clocker/docker/entity/container/application/VanillaDockerApplicationImpl.java
@@ -50,12 +50,13 @@ public class VanillaDockerApplicationImpl extends SoftwareProcessImpl implements
     @Override
     protected void connectSensors() {
         connectServiceUpIsRunning();
+
         super.connectSensors();
     }
 
     @Override
-    public void preStart() {
-        super.preStart();
+    protected void postStart() {
+        super.postStart();
 
         // Refresh the sensors that will be mapped, since we now have a location for the enricher to use
         for (AttributeSensor sensor : Iterables.filter(getEntityType().getSensors(), AttributeSensor.class)) {

--- a/docker/src/main/java/clocker/docker/entity/container/application/VanillaDockerApplicationSshDriver.java
+++ b/docker/src/main/java/clocker/docker/entity/container/application/VanillaDockerApplicationSshDriver.java
@@ -15,6 +15,8 @@
  */
 package clocker.docker.entity.container.application;
 
+import java.util.Map;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,6 +62,16 @@ public class VanillaDockerApplicationSshDriver extends AbstractSoftwareProcessSs
     @Override
     public void install() {
         LOG.info("Container installed on {}", getOwnerEntity());
+    }
+
+    @Override
+    public void copyRuntimeResources() {
+        Map<String, String> runtimeFiles = entity.getConfig(VanillaSoftwareProcess.RUNTIME_FILES);
+        Map<String, String> runtimeTemplates = entity.getConfig(VanillaSoftwareProcess.RUNTIME_TEMPLATES);
+        if ((runtimeFiles != null && runtimeFiles.size() > 0) ||
+                (runtimeTemplates != null && runtimeTemplates.size() > 0)) {
+            super.copyRuntimeResources();
+        }
     }
 
     @Override

--- a/docker/src/main/java/clocker/docker/entity/container/application/VanillaDockerApplicationSshDriver.java
+++ b/docker/src/main/java/clocker/docker/entity/container/application/VanillaDockerApplicationSshDriver.java
@@ -83,5 +83,4 @@ public class VanillaDockerApplicationSshDriver extends AbstractSoftwareProcessSs
                 .execute();
         }
     }
-
 }

--- a/docker/src/main/java/clocker/docker/entity/util/DockerAttributes.java
+++ b/docker/src/main/java/clocker/docker/entity/util/DockerAttributes.java
@@ -119,7 +119,7 @@ public class DockerAttributes {
 
     public static final ConfigKey<List<String>> DOCKER_CONTAINER_VOLUME_EXPORT = ConfigKeys.newConfigKey(
             new TypeToken<List<String>>() { },
-            "docker.container.volumes", "Container volume export configuration");
+            "docker.container.volumes.export", "Container volume export configuration");
 
     public static final AttributeSensor<Map<String, String>> DOCKER_VOLUME_MAPPING = Sensors.newSensor(
             new TypeToken<Map<String, String>>() { },

--- a/docker/src/main/java/clocker/docker/entity/util/DockerAttributes.java
+++ b/docker/src/main/java/clocker/docker/entity/util/DockerAttributes.java
@@ -125,6 +125,10 @@ public class DockerAttributes {
             new TypeToken<List<String>>() { },
             "docker.container.volumes.export", "Container volume export configuration");
 
+    public static final ConfigKey<List<String>> DOCKER_CONTAINER_VOLUMES_FROM = ConfigKeys.newConfigKey(
+            new TypeToken<List<String>>() { },
+            "docker.container.volumes.import", "Container volume import configuration");
+
     public static final AttributeSensor<Map<String, String>> DOCKER_VOLUME_MAPPING = Sensors.newSensor(
             new TypeToken<Map<String, String>>() { },
             "docker.container.volumes", "Container volume mappings");

--- a/docker/src/main/java/clocker/docker/entity/util/DockerAttributes.java
+++ b/docker/src/main/java/clocker/docker/entity/util/DockerAttributes.java
@@ -91,8 +91,7 @@ public class DockerAttributes {
             "docker.container.name", "The name of the Docker container");
 
     public static final ConfigKey<String> DOCKER_LOGIN_USER = ConfigKeys.newConfigKeyWithDefault(
-            ConfigKeys.newConfigKeyWithPrefix("docker.", JcloudsLocationConfig.LOGIN_USER),
-            "root");
+            ConfigKeys.newConfigKeyWithPrefix("docker.", JcloudsLocationConfig.LOGIN_USER), "root");
 
     public static final ConfigKey<String> DOCKER_LOGIN_PASSWORD = ConfigKeys.newConfigKeyWithPrefix("docker.", JcloudsLocationConfig.LOGIN_USER_PASSWORD);
 
@@ -112,7 +111,7 @@ public class DockerAttributes {
             "docker.memory", "Container memory configuration");
 
     public static final ConfigKey<Boolean> PRIVILEGED = ConfigKeys.newBooleanConfigKey(
-            "docker.container.privileged", "Set to true if the container is to be provileged", Boolean.TRUE);
+            "docker.container.privileged", "Set to true if the container is to be privileged", Boolean.TRUE);
 
     public static final ConfigKey<Boolean> MANAGED = ConfigKeys.newBooleanConfigKey(
             "docker.container.managed", "Set to false if the container is not managed by Brooklyn and Clocker", Boolean.TRUE);
@@ -125,9 +124,12 @@ public class DockerAttributes {
             new TypeToken<List<String>>() { },
             "docker.container.volumes.export", "Container volume export configuration");
 
-    public static final ConfigKey<List<String>> DOCKER_CONTAINER_VOLUMES_FROM = ConfigKeys.newConfigKey(
-            new TypeToken<List<String>>() { },
-            "docker.container.volumes.import", "Container volume import configuration");
+    public static final ConfigKey<List<String>> DOCKER_CONTAINER_VOLUMES_FROM = ConfigKeys.builder(new TypeToken<List<String>>() { })
+            .name("docker.container.volumes.import")
+            .description("Container volume import configuration")
+            .defaultValue(ImmutableList.<String>of())
+            .inheritance(ConfigInheritance.NONE)
+            .build();
 
     public static final AttributeSensor<Map<String, String>> DOCKER_VOLUME_MAPPING = Sensors.newSensor(
             new TypeToken<Map<String, String>>() { },

--- a/docker/src/main/java/clocker/docker/entity/util/DockerAttributes.java
+++ b/docker/src/main/java/clocker/docker/entity/util/DockerAttributes.java
@@ -78,7 +78,11 @@ public class DockerAttributes {
 
     public static final AttributeSensorAndConfigKey<List<String>, List<String>> DOCKER_IMAGE_ENTRYPOINT = ConfigKeys.newSensorAndConfigKey(
             new TypeToken<List<String>>() { },
-            "docker.image.entrypoint", "Optional replacement for the image entrypoint command");
+            "docker.image.entrypoint", "Optional replacement for the image entrypoint command and arguments");
+
+    public static final AttributeSensorAndConfigKey<List<String>, List<String>> DOCKER_IMAGE_COMMANDS = ConfigKeys.newSensorAndConfigKey(
+            new TypeToken<List<String>>() { },
+            "docker.image.commands", "Optional replacement for the image commands");
 
     public static final AttributeSensorAndConfigKey<String, String> DOCKER_HARDWARE_ID = ConfigKeys.newStringSensorAndConfigKey(
             "docker.hardwareId", "The ID of a Docker hardware type to use for a container", "small");

--- a/docker/src/main/java/clocker/docker/entity/util/DockerUtils.java
+++ b/docker/src/main/java/clocker/docker/entity/util/DockerUtils.java
@@ -265,8 +265,8 @@ public class DockerUtils {
         Optional<String> unique = getUniqueContainerName(target);
         if (unique.isPresent()) {
             String name = unique.get();
-            int underscore = name.lastIndexOf('_');
-            return Optional.of(name.substring(0, underscore));
+            String suffix = "_" + target.getId();
+            return Optional.of(Strings.removeFromEnd(name, suffix));
         } else {
             return Optional.absent();
         }
@@ -282,7 +282,7 @@ public class DockerUtils {
     private static String getContainerNameFromPlan(Entity target) {
         String planId = target.config().get(BrooklynCampConstants.PLAN_ID);
         if (planId != null) {
-            //Plan IDs are not unique even in a single application
+            // Plan IDs are not unique even in a single application
             return planId + "_" + target.getId();
         } else {
             return null;

--- a/docker/src/main/java/clocker/docker/location/DockerContainerLocation.java
+++ b/docker/src/main/java/clocker/docker/location/DockerContainerLocation.java
@@ -19,7 +19,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
 import static org.apache.brooklyn.util.ssh.BashCommands.sudo;
 
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetAddress;
 import java.util.LinkedList;
 import java.util.List;
@@ -58,6 +60,7 @@ import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.net.Cidr;
 import org.apache.brooklyn.util.net.Protocol;
+import org.apache.brooklyn.util.net.Urls;
 import org.apache.brooklyn.util.ssh.IptablesCommands;
 import org.apache.brooklyn.util.ssh.IptablesCommands.Chain;
 import org.apache.brooklyn.util.ssh.IptablesCommands.Policy;
@@ -86,9 +89,12 @@ public class DockerContainerLocation extends SshMachineLocation implements Suppo
     @SetFromFlag("owner")
     private DockerContainer dockerContainer;
 
+    private SshMachineLocation hostMachine;
+
     @Override
     public void init() {
         super.init();
+        hostMachine = getOwner().getDockerHost().getDynamicLocation().getMachine();
     }
 
     @Override
@@ -116,16 +122,15 @@ public class DockerContainerLocation extends SshMachineLocation implements Suppo
      */
     private void addIptablesRule(Integer port) {
         if (getOwner().config().get(DockerHost.OPEN_IPTABLES)) {
-            SshMachineLocation host = getOwner().getDockerHost().getDynamicLocation().getMachine();
-            LOG.debug("Using iptables to add access for TCP/{} to {}", port, host);
+            LOG.debug("Using iptables to add access for TCP/{} to {}", port, hostMachine);
             List<String> commands = ImmutableList.of(
                     sudo("iptables -L INPUT -nv | grep -q 'tcp dpt:"+port+"'"),
                     format("if [ $? -eq 0 ]; then ( %s ); else ( %s ); fi",
                             sudo("iptables -C INPUT -s 0/0 -p tcp --dport "+port+" -j ACCEPT"),
                             IptablesCommands.insertIptablesRule(Chain.INPUT, Protocol.TCP, port, Policy.ACCEPT)));
-            int result = host.execCommands(format("Open iptables TCP/%d", port), commands);
+            int result = hostMachine.execCommands(format("Open iptables TCP/%d", port), commands);
             if (result != 0) {
-                String msg = format("Error running iptables update for TCP/%d on %s", port, host);
+                String msg = format("Error running iptables update for TCP/%d on %s", port, hostMachine);
                 LOG.error(msg);
                 throw new RuntimeException(msg);
             }
@@ -188,12 +193,13 @@ public class DockerContainerLocation extends SshMachineLocation implements Suppo
         for (String commandString : filtered) {
             parseDockerCallback(commandString);
         }
-        if (getOwner().config().get(DockerContainer.DOCKER_USE_SSH)) {
+        boolean entitySsh = Boolean.TRUE.equals(entity.config().get(DockerContainer.DOCKER_USE_SSH));
+        boolean dockerSsh = Boolean.TRUE.equals(getOwner().config().get(DockerContainer.DOCKER_USE_SSH));
+        if (entitySsh && dockerSsh) {
             return super.execScript(props, summaryForLogging, commands, env);
         } else {
             Map<String,?> nonPortProps = Maps.filterKeys(props, Predicates.not(Predicates.containsPattern("port")));
-            SshMachineLocation host = getOwner().getDockerHost().getDynamicLocation().getMachine();
-            return host.execCommands(nonPortProps, summaryForLogging, getExecScript(commands, env));
+            return hostMachine.execCommands(nonPortProps, summaryForLogging, getExecScript(commands, env));
         }
     }
 
@@ -203,19 +209,20 @@ public class DockerContainerLocation extends SshMachineLocation implements Suppo
         for (String commandString : filtered) {
             parseDockerCallback(commandString);
         }
-        if (getOwner().config().get(DockerContainer.DOCKER_USE_SSH)) {
+        boolean entitySsh = Boolean.TRUE.equals(entity.config().get(DockerContainer.DOCKER_USE_SSH));
+        boolean dockerSsh = Boolean.TRUE.equals(getOwner().config().get(DockerContainer.DOCKER_USE_SSH));
+        if (entitySsh && dockerSsh) {
             return super.execCommands(props, summaryForLogging, commands, env);
         } else {
             Map<String,?> nonPortProps = Maps.filterKeys(props, Predicates.not(Predicates.containsPattern("port")));
-            SshMachineLocation host = getOwner().getDockerHost().getDynamicLocation().getMachine();
-            return host.execCommands(nonPortProps, summaryForLogging, getExecCommands(commands, env));
+            return hostMachine.execCommands(nonPortProps, summaryForLogging, getExecCommands(commands, env));
         }
     }
 
     private List<String> getExecScript(List<String> commands, Map<String,?> env) {
         StringBuilder target = new StringBuilder("docker exec ")
                 .append(dockerContainer.getContainerId())
-                .append(" '");
+                .append(" /bin/bash -c '");
         Joiner.on(";").appendTo(target, Iterables.concat(getEnvVarCommands(env), commands));
         target.append("'");
         return ImmutableList.of(target.toString());
@@ -224,9 +231,9 @@ public class DockerContainerLocation extends SshMachineLocation implements Suppo
     private List<String> getExecCommands(List<String> commands, Map<String,?> env) {
         List<String> result = Lists.newLinkedList();
         result.addAll(getEnvVarCommands(env));
-        String prefix = "docker exec " + dockerContainer.getContainerId() + " ";
+        String exec = "docker exec %s /bin/bash -c '%s'";
         for (String command : commands) {
-            result.add(prefix + command);
+            result.add(String.format(exec, dockerContainer.getContainerId(), command));
         }
         return result;
     }
@@ -269,13 +276,75 @@ public class DockerContainerLocation extends SshMachineLocation implements Suppo
     }
 
     @Override
+    public int copyTo(final Map<String,?> props, final InputStream src, final long filesize, final String destination) {
+        return copyTo(props, src, destination);
+    }
+
+    @Override
+    public int copyTo(final Map<String,?> props, final InputStream src, final String destination) {
+        File tmp = null;
+        try {
+            tmp = File.createTempFile(dockerContainer.getId(), Urls.getBasename(destination));
+            Map<String,?> nonPortProps = Maps.filterKeys(props, Predicates.not(Predicates.containsPattern("port")));
+            hostMachine.copyTo(nonPortProps, src, tmp.getAbsolutePath());
+            copyFile(tmp, destination);
+            src.close();
+            return 0;
+        } catch (IOException ioe) {
+            throw Exceptions.propagate(ioe);
+        } finally {
+            if (tmp != null) tmp.delete();
+        }
+    }
+
+    @Override
+    public int copyTo(Map<String,?> props, File src, String destination) {
+        File tmp = null;
+        try {
+            tmp = File.createTempFile(dockerContainer.getId(), Urls.getBasename(destination));
+            Map<String,?> nonPortProps = Maps.filterKeys(props, Predicates.not(Predicates.containsPattern("port")));
+            hostMachine.copyTo(nonPortProps, src, tmp);
+            copyFile(tmp, destination);
+            return 0;
+        } catch (IOException ioe) {
+            throw Exceptions.propagate(ioe);
+        } finally {
+            if (tmp != null) tmp.delete();
+        }
+    }
+
+    private void copyFile(File src, String dst) {
+        String cp = String.format("cp %s %s:%s", src.getAbsolutePath(), dockerContainer.getContainerId(), dst);
+        String output = getOwner().getDockerHost().runDockerCommand(cp);
+        LOG.info("Copying to {}:{} - result: {}", new Object[] { dockerContainer.getContainerId(), dst, output });
+    }
+
+    @Override
+    public int copyFrom(final Map<String,?> props, final String remote, final String local) {
+        File tmp = null;
+        try {
+            tmp = File.createTempFile(dockerContainer.getId(), Urls.getBasename(local));
+            String cp = String.format("cp %s:%s %s", dockerContainer.getContainerId(), remote, tmp.getAbsolutePath());
+            String output = getOwner().getDockerHost().runDockerCommand(cp);
+            Map<String,?> nonPortProps = Maps.filterKeys(props, Predicates.not(Predicates.containsPattern("port")));
+            hostMachine.copyFrom(nonPortProps, tmp.getAbsolutePath(), local);
+            LOG.info("Copying from {}:{} to {} - result: {}", new Object[] { dockerContainer.getContainerId(), remote, local, output });
+        } catch (IOException ioe) {
+            throw Exception.propagate(ioe);
+        } finally {
+            if (tmp != null) tmp.delete();
+        }
+        return 0;
+    }
+
+    @Override
     public void releasePort(int portNumber) {
         machine.releasePort(portNumber);
     }
 
     @Override
     public InetAddress getAddress() {
-        return getOwner().getDockerHost().getDynamicLocation().getMachine().getAddress();
+        return hostMachine.getAddress();
     }
 
     @Override

--- a/docker/src/main/java/clocker/docker/location/DockerLocation.java
+++ b/docker/src/main/java/clocker/docker/location/DockerLocation.java
@@ -21,6 +21,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Semaphore;
@@ -68,6 +69,7 @@ import org.apache.brooklyn.entity.group.DynamicCluster;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
+import org.apache.brooklyn.util.core.mutex.WithMutexes;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 
 public class DockerLocation extends AbstractLocation implements DockerVirtualLocation, MachineProvisioningLocation<MachineLocation>,
@@ -184,27 +186,19 @@ public class DockerLocation extends AbstractLocation implements DockerVirtualLoc
         }
         Entity entity = (Entity) context;
 
-        // Get the available hosts based on placement strategies
+        // Get the available hosts
         List<DockerHostLocation> available = getDockerHostLocations();
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Placement for: {}", Iterables.toString(Iterables.transform(available, EntityFunctions.id())));
-        }
-        for (DockerAwarePlacementStrategy strategy : strategies) {
-            available = strategy.filterLocations(available, entity);
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Placement after {}: {}", strategy, Iterables.toString(Iterables.transform(available, EntityFunctions.id())));
-            }
-        }
+        LOG.debug("Placement for: {}", Iterables.toString(Iterables.transform(available, EntityFunctions.id())));
+
+        // Apply placement strategies
         List<DockerAwarePlacementStrategy> entityStrategies = entity.config().get(DockerAttributes.PLACEMENT_STRATEGIES);
-        if (entityStrategies != null && entityStrategies.size() > 0) {
-            for (DockerAwarePlacementStrategy strategy : entityStrategies) {
-                available = strategy.filterLocations(available, entity);
-            }
-        } else {
-            entityStrategies = ImmutableList.of();
+        if (entityStrategies == null) entityStrategies = ImmutableList.of();
+        for (DockerAwarePlacementStrategy strategy : Iterables.concat(strategies, entityStrategies)) {
+            available = strategy.filterLocations(available, entity);
+            LOG.debug("Placement after {}: {}", strategy, Iterables.toString(Iterables.transform(available, EntityFunctions.id())));
         }
 
-        // Use the docker strategy to add a new host
+        // Use the provisioning strategy to add a new host
         DockerHostLocation machine = null;
         DockerHost dockerHost = null;
         if (available.size() > 0) {
@@ -245,13 +239,20 @@ public class DockerLocation extends AbstractLocation implements DockerVirtualLoc
         Entities.waitForServiceUp(dockerHost);
 
         // Obtain a new Docker container location, save and return it
-        if (LOG.isDebugEnabled()) {
+        try {
             LOG.debug("Obtain a new container from {} for {}", machine, entity);
+            Map<?,?> hostFlags = MutableMap.copyOf(flags);
+            DockerContainerLocation container = machine.obtain(hostFlags);
+            containers.put(machine, container.getId());
+            return container;
+        } finally {
+            // Release any placement strategy locks
+            for (DockerAwarePlacementStrategy strategy : Iterables.concat(strategies, entityStrategies)) {
+                if (strategy instanceof WithMutexes) {
+                    ((WithMutexes) strategy).releaseMutex(entity.getApplicationId());
+                }
+            }
         }
-        Map<?,?> hostFlags = MutableMap.copyOf(flags);
-        DockerContainerLocation container = machine.obtain(hostFlags);
-        containers.put(machine, container.getId());
-        return container;
     }
 
     @Override
@@ -270,15 +271,11 @@ public class DockerLocation extends AbstractLocation implements DockerVirtualLoc
             throw new IllegalArgumentException("Request to release "+machine+", but this machine is not currently allocated");
         }
         DockerHostLocation host = Iterables.getOnlyElement(set);
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Request to remove container mapping {} to {}", host, id);
-        }
+        LOG.debug("Request to remove container mapping {} to {}", host, id);
         host.release((DockerContainerLocation) machine);
         if (containers.remove(host, id)) {
             if (containers.get(host).isEmpty()) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Empty Docker host: {}", host);
-                }
+                LOG.debug("Empty Docker host: {}", host);
 
                 // Remove hosts when it has no containers, except for the last one
                 if (infrastructure.config().get(DockerInfrastructure.REMOVE_EMPTY_DOCKER_HOSTS) && set.size() > 1) {

--- a/docker/src/main/java/clocker/docker/location/strategy/AbstractDockerPlacementStrategy.java
+++ b/docker/src/main/java/clocker/docker/location/strategy/AbstractDockerPlacementStrategy.java
@@ -17,6 +17,8 @@ package clocker.docker.location.strategy;
 
 import clocker.docker.entity.DockerInfrastructure;
 
+import com.google.common.base.CaseFormat;
+
 import org.apache.brooklyn.core.objs.BasicConfigurableObject;
 
 /**
@@ -29,7 +31,12 @@ public abstract class AbstractDockerPlacementStrategy extends BasicConfigurableO
 
     @Override
     public String toString() {
-        return String.format("DockerAwarePlacementStrategy(%s@%s)", getClass().getSimpleName(), getId());
+        return String.format("DockerAwarePlacementStrategy(%s@%s)", getShortName(), getId());
+    }
+
+    @Override
+    public String getShortName() {
+        return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_HYPHEN, getClass().getSimpleName());
     }
 
 }

--- a/docker/src/main/java/clocker/docker/location/strategy/DockerAwarePlacementStrategy.java
+++ b/docker/src/main/java/clocker/docker/location/strategy/DockerAwarePlacementStrategy.java
@@ -22,13 +22,14 @@ import clocker.docker.location.DockerHostLocation;
 import clocker.docker.location.DockerVirtualLocation;
 
 import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.objs.HasShortName;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 
 /**
  * Placement strategy for Docker containers in host clusters.
  */
-public interface DockerAwarePlacementStrategy {
+public interface DockerAwarePlacementStrategy extends HasShortName {
 
     @SetFromFlag("infrastructure")
     ConfigKey<DockerInfrastructure> DOCKER_INFRASTRUCTURE = DockerVirtualLocation.INFRASTRUCTURE;

--- a/docker/src/main/java/clocker/docker/location/strategy/GroupPlacementStrategy.java
+++ b/docker/src/main/java/clocker/docker/location/strategy/GroupPlacementStrategy.java
@@ -139,7 +139,7 @@ public class GroupPlacementStrategy extends AbstractDockerPlacementStrategy impl
     }
 
     /**
-     * Look up the {@link monitor} for an application.
+     * Look up the {@link Monitor} for an application.
      *
      * @return {@code null} if the monitor has not been created yet
      */
@@ -151,7 +151,7 @@ public class GroupPlacementStrategy extends AbstractDockerPlacementStrategy impl
     }
 
     /**
-     * Create a new {@link monitor} and optionally the {@link #monitor_MAP map}
+     * Create a new {@link Monitor} and optionally the {@link #MONITOR_MAP map}
      * for an application. Uses existing monitor if it already exists.
      *
      * @return The monitor for the scope that is stored in the {@link Map map}.

--- a/docker/src/main/java/clocker/docker/location/strategy/GroupPlacementStrategy.java
+++ b/docker/src/main/java/clocker/docker/location/strategy/GroupPlacementStrategy.java
@@ -15,47 +15,114 @@
  */
 package clocker.docker.location.strategy;
 
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.concurrent.ThreadSafe;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import clocker.docker.entity.container.DockerContainer;
 import clocker.docker.location.DockerHostLocation;
 
+import com.google.common.annotations.Beta;
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.reflect.TypeToken;
+import com.google.common.util.concurrent.Monitor;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.EntityPredicates;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
+import org.apache.brooklyn.util.core.mutex.WithMutexes;
 
 /**
- * Strategy that requires entities with the same parent to use the same host.
+ * A {@link DockerAwarePlacementStrategy strategy} that requires entities with
+ * the same parent to use the same host.
+ *
  * Can be configured to require exclusive use of the host with the
- * {@code exclusive} option.
+ * {@link #REQUIRE_EXCLUSIVE exclusive} ({@code docker.constraint.exclusive})
+ * option set to {@code true}; normally {@code false}.
+ *
+ * @since 1.1.0
  */
-public class GroupPlacementStrategy extends BasicDockerPlacementStrategy {
+@Beta
+@ThreadSafe
+public class GroupPlacementStrategy extends AbstractDockerPlacementStrategy implements WithMutexes, Predicate<DockerHostLocation> {
 
     private static final Logger LOG = LoggerFactory.getLogger(GroupPlacementStrategy.class);
 
-    @SetFromFlag("requireEmpty")
+    private static final Object lock = new Object[0];
+
+    private Entity entity;
+
+    @SetFromFlag("exclusive")
     public static final ConfigKey<Boolean> REQUIRE_EXCLUSIVE = ConfigKeys.newBooleanConfigKey(
             "docker.constraint.exclusive",
             "Whether the Docker host must be exclusive to this application; by default other applications can co-exist",
             Boolean.FALSE);
 
+    @SetFromFlag("monitorMap")
+    public static final ConfigKey<Map<String, Monitor>> MONITOR_MAP = ConfigKeys.newConfigKey(
+            new TypeToken<Map<String, Monitor>>() { },
+            "groupPlacementStrategy.map.monitors",
+            "A mapping from application IDs to monitors; used to synchronize threads during strategy execution.",
+            MutableMap.<String, Monitor>of());
+
+    @Override
+    public List<DockerHostLocation> filterLocations(List<DockerHostLocation> locations, Entity context) {
+        if (locations == null || locations.isEmpty()) {
+            return ImmutableList.of();
+        }
+        entity = context;
+        if (getDockerInfrastructure() == null) config().set(DOCKER_INFRASTRUCTURE, Iterables.getLast(locations).getDockerInfrastructure());
+        List<DockerHostLocation> available = MutableList.copyOf(locations);
+
+        Monitor monitor = null;
+        boolean found = false;
+        synchronized (lock) {
+            monitor = lookupMonitor(entity.getApplicationId());
+            found = (monitor != null);
+            if (!found) {
+                createMonitor(entity.getApplicationId());
+            }
+        }
+        if (found) {
+            monitor.enter();
+        }
+
+        Optional<DockerHostLocation> chosen = Iterables.tryFind(available, this);
+        return ImmutableList.copyOf(chosen.asSet());
+    }
+
     @Override
     public boolean apply(DockerHostLocation input) {
         boolean requireExclusive = config().get(REQUIRE_EXCLUSIVE);
-        String dockerApplicationId = input.getOwner().getApplicationId();
-        Iterable<Entity> deployed = Iterables.filter(input.getDockerContainerList(), Predicates.not(EntityPredicates.applicationIdEqualTo(dockerApplicationId)));
+        Iterable<Entity> deployed = Iterables.filter(Iterables.transform(input.getDockerContainerList(),
+                new Function<Entity, Entity>() {
+                    @Override
+                    public Entity apply(Entity input) {
+                        return entity.sensors().get(DockerContainer.ENTITY);
+                    }
+                }), Predicates.notNull());
         Entity parent = entity.getParent();
         String applicationId = entity.getApplicationId();
+
         Iterable<Entity> sameApplication = Iterables.filter(deployed, EntityPredicates.applicationIdEqualTo(applicationId));
         if (requireExclusive && Iterables.size(deployed) > Iterables.size(sameApplication)) {
             LOG.debug("Found entities not in {}; required exclusive. Reject: {}", applicationId, input);
             return false;
         }
+
         if (Iterables.isEmpty(sameApplication)) {
             LOG.debug("No entities present from {}. Accept: {}", applicationId, input);
             return true;
@@ -67,6 +134,70 @@ public class GroupPlacementStrategy extends BasicDockerPlacementStrategy {
             } else {
                 LOG.debug("All entities from {} have same parent. Accept: {}", applicationId, input);
                 return true;
+            }
+        }
+    }
+
+    /**
+     * Look up the {@link monitor} for an application.
+     *
+     * @return {@code null} if the monitor has not been created yet
+     */
+    protected Monitor lookupMonitor(String mutexId) {
+        synchronized (lock) {
+            Map<String, Monitor> map = getDockerInfrastructure().config().get(MONITOR_MAP);
+            return (map != null) ? map.get(mutexId) : null;
+        }
+    }
+
+    /**
+     * Create a new {@link monitor} and optionally the {@link #monitor_MAP map}
+     * for an application. Uses existing monitor if it already exists.
+     *
+     * @return The monitor for the scope that is stored in the {@link Map map}.
+     */
+    protected Monitor createMonitor(String mutexId) {
+        synchronized (lock) {
+            Map<String, Monitor> map = getDockerInfrastructure().config().get(MONITOR_MAP);
+            if (map == null) {
+                map = MutableMap.<String, Monitor>of();
+            }
+
+            if (!map.containsKey(mutexId)) {
+                map.put(mutexId, new Monitor());
+                getDockerInfrastructure().config().set(MONITOR_MAP, map);
+            }
+            Monitor monitor = map.get(mutexId);
+
+            return monitor;
+        }
+    }
+
+    @Override
+    public boolean hasMutex(String mutexId) { throw new UnsupportedOperationException(); }
+
+    @Override
+    public void acquireMutex(String mutexId, String description) throws InterruptedException {
+        synchronized (lock) {
+            Monitor monitor = createMonitor(mutexId);
+            monitor.enter();
+        }
+    }
+
+    @Override
+    public boolean tryAcquireMutex(String mutexId, String description) {
+        synchronized (lock) {
+            Monitor monitor = createMonitor(mutexId);
+            return monitor.tryEnter();
+        }
+    }
+
+    @Override
+    public void releaseMutex(String mutexId) {
+        synchronized (lock) {
+            Monitor monitor = lookupMonitor(mutexId);
+            if (monitor != null && monitor.isOccupiedByCurrentThread()) {
+                monitor.leave();
             }
         }
     }

--- a/docker/src/main/java/clocker/docker/location/strategy/GroupPlacementStrategy.java
+++ b/docker/src/main/java/clocker/docker/location/strategy/GroupPlacementStrategy.java
@@ -27,7 +27,6 @@ import clocker.docker.entity.container.DockerContainer;
 import clocker.docker.location.DockerHostLocation;
 
 import com.google.common.annotations.Beta;
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
@@ -39,6 +38,7 @@ import com.google.common.util.concurrent.Monitor;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.EntityFunctions;
 import org.apache.brooklyn.core.entity.EntityPredicates;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -57,13 +57,10 @@ import org.apache.brooklyn.util.core.mutex.WithMutexes;
  */
 @Beta
 @ThreadSafe
-public class GroupPlacementStrategy extends AbstractDockerPlacementStrategy implements WithMutexes, Predicate<DockerHostLocation> {
+public class GroupPlacementStrategy extends AbstractDockerPlacementStrategy implements WithMutexes {
 
     private static final Logger LOG = LoggerFactory.getLogger(GroupPlacementStrategy.class);
-
-    private static final Object lock = new Object[0];
-
-    private Entity entity;
+    private static final Object LOCK = new Object[0];
 
     @SetFromFlag("exclusive")
     public static final ConfigKey<Boolean> REQUIRE_EXCLUSIVE = ConfigKeys.newBooleanConfigKey(
@@ -71,70 +68,119 @@ public class GroupPlacementStrategy extends AbstractDockerPlacementStrategy impl
             "Whether the Docker host must be exclusive to this application; by default other applications can co-exist",
             Boolean.FALSE);
 
-    @SetFromFlag("monitorMap")
     public static final ConfigKey<Map<String, Monitor>> MONITOR_MAP = ConfigKeys.newConfigKey(
             new TypeToken<Map<String, Monitor>>() { },
             "groupPlacementStrategy.map.monitors",
-            "A mapping from application IDs to monitors; used to synchronize threads during strategy execution.",
-            MutableMap.<String, Monitor>of());
+            "A mapping from application IDs to monitors; used to synchronize threads during strategy execution.");
 
     @Override
-    public List<DockerHostLocation> filterLocations(List<DockerHostLocation> locations, Entity context) {
+    public List<DockerHostLocation> filterLocations(List<DockerHostLocation> locations, Entity entity) {
         if (locations == null || locations.isEmpty()) {
             return ImmutableList.of();
         }
-        entity = context;
         if (getDockerInfrastructure() == null) config().set(DOCKER_INFRASTRUCTURE, Iterables.getLast(locations).getDockerInfrastructure());
         List<DockerHostLocation> available = MutableList.copyOf(locations);
+        boolean requireExclusive = config().get(REQUIRE_EXCLUSIVE);
 
-        Monitor monitor = null;
-        boolean found = false;
-        synchronized (lock) {
-            monitor = lookupMonitor(entity.getApplicationId());
-            found = (monitor != null);
-            if (!found) {
-                createMonitor(entity.getApplicationId());
-            }
-        }
-        if (found) {
-            monitor.enter();
+        Monitor monitor = createMonitor(entity.getApplicationId());
+        monitor.enter();
+        LOG.debug("Placing {} from {} with parent {}", new Object[] { entity, entity.getApplicationId(), entity.getParent() });
+
+        // Find hosts with entities from our application deployed there
+        Iterable<DockerHostLocation> sameApplication = Iterables.filter(available, hasApplicationId(entity.getApplicationId()));
+
+        // Check if hosts have any deployed entities that share a parent with the input entity
+        Optional<DockerHostLocation> sameParent = Iterables.tryFind(sameApplication, childrenOf(entity.getParent()));
+        if (sameParent.isPresent()) {
+            LOG.debug("Returning {} for {} placement", sameParent.get(), entity);
+            return ImmutableList.copyOf(sameParent.asSet());
         }
 
-        Optional<DockerHostLocation> chosen = Iterables.tryFind(available, this);
-        return ImmutableList.copyOf(chosen.asSet());
+        // Remove hosts if they do not have any entities from our application deployed there
+        Iterables.removeIf(available, hasApplicationId(entity.getApplicationId()));
+        if (requireExclusive) {
+            Iterables.removeIf(available, nonEmpty());
+        }
+        LOG.debug("Returning {} for {} placement", Iterables.toString(available), entity);
+        return available;
     }
 
-    @Override
-    public boolean apply(DockerHostLocation input) {
-        boolean requireExclusive = config().get(REQUIRE_EXCLUSIVE);
-        Iterable<Entity> deployed = Iterables.filter(Iterables.transform(input.getDockerContainerList(),
-                new Function<Entity, Entity>() {
-                    @Override
-                    public Entity apply(Entity input) {
-                        return entity.sensors().get(DockerContainer.ENTITY);
-                    }
-                }), Predicates.notNull());
-        Entity parent = entity.getParent();
-        String applicationId = entity.getApplicationId();
+    private static Predicate<DockerHostLocation> childrenOf(Entity parent) {
+        return new ChildrenOfPredicate(parent);
+    }
 
-        Iterable<Entity> sameApplication = Iterables.filter(deployed, EntityPredicates.applicationIdEqualTo(applicationId));
-        if (requireExclusive && Iterables.size(deployed) > Iterables.size(sameApplication)) {
-            LOG.debug("Found entities not in {}; required exclusive. Reject: {}", applicationId, input);
-            return false;
+    private static class ChildrenOfPredicate implements Predicate<DockerHostLocation> {
+        private Entity parent;
+
+        public ChildrenOfPredicate(Entity parent) {
+            this.parent = parent;
         }
 
-        if (Iterables.isEmpty(sameApplication)) {
-            LOG.debug("No entities present from {}. Accept: {}", applicationId, input);
-            return true;
-        } else {
-            Iterable<Entity> sameParent = Iterables.filter(sameApplication, EntityPredicates.isChildOf(parent));
+        @Override
+        public boolean apply(DockerHostLocation input) {
+            Iterable<Entity> deployed = Iterables.filter(
+                    Iterables.transform(input.getDockerContainerList(), EntityFunctions.config(DockerContainer.ENTITY.getConfigKey())),
+                    Predicates.notNull());
+
+            Iterable<Entity> sameParent = Iterables.filter(deployed, EntityPredicates.isChildOf(parent));
+            LOG.debug("Found {} deployed to {} with parent {}",
+                    new Object[] { Iterables.toString(sameParent), input, parent });
+
             if (Iterables.isEmpty(sameParent)) {
-                LOG.debug("All entities from {} have different parent. Reject: {}", applicationId, input);
+                LOG.debug("No entities with parent {} on {}", parent, input );
                 return false;
             } else {
-                LOG.debug("All entities from {} have same parent. Accept: {}", applicationId, input);
+                LOG.debug("Found entities with parent {} on {}", parent, input );
                 return true;
             }
+        }
+    }
+
+    private Predicate<DockerHostLocation> hasApplicationId(String applicationId) {
+        return new HasApplicationIdPredicate(applicationId);
+    }
+
+    private class HasApplicationIdPredicate implements Predicate<DockerHostLocation> {
+        private String applicationId;
+
+        public HasApplicationIdPredicate(String applicationId) {
+            this.applicationId = applicationId;
+        }
+
+        @Override
+        public boolean apply(DockerHostLocation input) {
+            Iterable<Entity> deployed = Iterables.filter(
+                    Iterables.transform(input.getDockerContainerList(), EntityFunctions.config(DockerContainer.ENTITY.getConfigKey())),
+                    Predicates.notNull());
+            LOG.debug("Found {} containers on {}", Iterables.toString(input.getDockerContainerList()), input);
+            LOG.debug("Found {} entities deployed to {}", Iterables.toString(deployed), input);
+
+            Iterable<Entity> sameApplication = Iterables.filter(deployed, EntityPredicates.applicationIdEqualTo(applicationId));
+            LOG.debug("Found {} deployed to {} with application id {}",
+                    new Object[] { Iterables.toString(sameApplication), input, applicationId });
+
+            if (Iterables.isEmpty(sameApplication)) {
+                LOG.debug("No entities with application id {} on {}", applicationId, input);
+                return false;
+            } else {
+                LOG.debug("Found entities with application id {} on {}", applicationId, input);
+                return true;
+            }
+        }
+    }
+
+    private Predicate<DockerHostLocation> nonEmpty() {
+        return new NonEmptyPredicate();
+    }
+
+    private class NonEmptyPredicate implements Predicate<DockerHostLocation> {
+        @Override
+        public boolean apply(DockerHostLocation input) {
+            Iterable<Entity> deployed = Iterables.filter(
+                    Iterables.transform(input.getDockerContainerList(), EntityFunctions.config(DockerContainer.ENTITY.getConfigKey())),
+                    Predicates.notNull());
+
+            return !Iterables.isEmpty(deployed);
         }
     }
 
@@ -144,7 +190,7 @@ public class GroupPlacementStrategy extends AbstractDockerPlacementStrategy impl
      * @return {@code null} if the monitor has not been created yet
      */
     protected Monitor lookupMonitor(String mutexId) {
-        synchronized (lock) {
+        synchronized (LOCK) {
             Map<String, Monitor> map = getDockerInfrastructure().config().get(MONITOR_MAP);
             return (map != null) ? map.get(mutexId) : null;
         }
@@ -157,7 +203,7 @@ public class GroupPlacementStrategy extends AbstractDockerPlacementStrategy impl
      * @return The monitor for the scope that is stored in the {@link Map map}.
      */
     protected Monitor createMonitor(String mutexId) {
-        synchronized (lock) {
+        synchronized (LOCK) {
             Map<String, Monitor> map = getDockerInfrastructure().config().get(MONITOR_MAP);
             if (map == null) {
                 map = MutableMap.<String, Monitor>of();
@@ -178,27 +224,21 @@ public class GroupPlacementStrategy extends AbstractDockerPlacementStrategy impl
 
     @Override
     public void acquireMutex(String mutexId, String description) throws InterruptedException {
-        synchronized (lock) {
-            Monitor monitor = createMonitor(mutexId);
-            monitor.enter();
-        }
+        Monitor monitor = createMonitor(mutexId);
+        monitor.enter();
     }
 
     @Override
     public boolean tryAcquireMutex(String mutexId, String description) {
-        synchronized (lock) {
-            Monitor monitor = createMonitor(mutexId);
-            return monitor.tryEnter();
-        }
+        Monitor monitor = createMonitor(mutexId);
+        return monitor.tryEnter();
     }
 
     @Override
     public void releaseMutex(String mutexId) {
-        synchronized (lock) {
-            Monitor monitor = lookupMonitor(mutexId);
-            if (monitor != null && monitor.isOccupiedByCurrentThread()) {
-                monitor.leave();
-            }
+        Monitor monitor = lookupMonitor(mutexId);
+        if (monitor != null && monitor.isOccupiedByCurrentThread()) {
+            monitor.leave();
         }
     }
 }

--- a/docker/src/main/java/clocker/docker/location/strategy/StrategyPredicates.java
+++ b/docker/src/main/java/clocker/docker/location/strategy/StrategyPredicates.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2014-2016 by Cloudsoft Corporation Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package clocker.docker.location.strategy;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.core.entity.EntityFunctions;
+import org.apache.brooklyn.core.entity.EntityPredicates;
+
+import brooklyn.entity.container.docker.DockerContainer;
+import brooklyn.location.docker.DockerHostLocation;
+
+/**
+ * A number of {@link Predicate predicates} that check for properties of
+ * a {@link DockerHostLocation}.
+ *
+ * @since 1.1.0
+ */
+@Beta
+public class StrategyPredicates {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StrategyPredicates.class);
+
+    /* Do not instantiate. */
+    private StrategyPredicates() { }
+
+    /** @see {@link ChildrenOfPredicate} */
+    public static Predicate<DockerHostLocation> childrenOf(Entity parent) {
+        return new ChildrenOfPredicate(parent);
+    }
+
+    /**
+     * A {@link Predicate} that checks if a {@link DockerHostLocation host} contains
+     * entities that are children of the given parent.
+     */
+    public static class ChildrenOfPredicate implements Predicate<DockerHostLocation> {
+        private Entity parent;
+
+        public ChildrenOfPredicate(Entity parent) {
+            this.parent = parent;
+        }
+
+        @Override
+        public boolean apply(DockerHostLocation input) {
+            Iterable<Entity> deployed = Iterables.filter(
+                    Iterables.transform(input.getDockerContainerList(), EntityFunctions.config(DockerContainer.ENTITY.getConfigKey())),
+                    Predicates.notNull());
+
+            Iterable<Entity> sameParent = Iterables.filter(deployed, EntityPredicates.isChildOf(parent));
+            if (Iterables.isEmpty(sameParent)) {
+                LOG.debug("No entities with parent {} on {}", parent, input );
+                return false;
+            } else {
+                LOG.debug("Found entities with parent {} on {}", parent, input );
+                return true;
+            }
+        }
+    }
+
+    /** @see {@link HasApplicationIdPredicate} */
+    public static Predicate<DockerHostLocation> hasApplicationId(String applicationId) {
+        return new HasApplicationIdPredicate(applicationId);
+    }
+
+    /**
+     * A {@link Predicate} that checks if a {@link DockerHostLocation host} contains
+     * entities that have the specified application ID.
+     */
+    public static class HasApplicationIdPredicate implements Predicate<DockerHostLocation> {
+        private String applicationId;
+
+        public HasApplicationIdPredicate(String applicationId) {
+            this.applicationId = applicationId;
+        }
+
+        @Override
+        public boolean apply(DockerHostLocation input) {
+            Iterable<Entity> deployed = Iterables.filter(
+                    Iterables.transform(input.getDockerContainerList(), EntityFunctions.config(DockerContainer.ENTITY.getConfigKey())),
+                    Predicates.notNull());
+
+            Iterable<Entity> sameApplication = Iterables.filter(deployed, EntityPredicates.applicationIdEqualTo(applicationId));
+            if (Iterables.isEmpty(sameApplication)) {
+                LOG.debug("No entities with application id {} on {}", applicationId, input);
+                return false;
+            } else {
+                LOG.debug("Found entities with application id {} on {}", applicationId, input);
+                return true;
+            }
+        }
+    }
+
+    /** @see {@link NonEmptyPredicate} */
+    public static Predicate<DockerHostLocation> nonEmpty() {
+        return new NonEmptyPredicate();
+    }
+
+    /**
+     * A {@link Predicate} that checks if a {@link DockerHostLocation host} has
+     * deployed entities.
+     */
+    public static class NonEmptyPredicate implements Predicate<DockerHostLocation> {
+        @Override
+        public boolean apply(DockerHostLocation input) {
+            Iterable<Entity> deployed = Iterables.filter(
+                    Iterables.transform(input.getDockerContainerList(), EntityFunctions.config(DockerContainer.ENTITY.getConfigKey())),
+                    Predicates.notNull());
+
+            return Iterables.size(deployed) > 0;
+        }
+    }
+
+}

--- a/docker/src/main/java/clocker/docker/location/strategy/StrategyPredicates.java
+++ b/docker/src/main/java/clocker/docker/location/strategy/StrategyPredicates.java
@@ -18,6 +18,9 @@ package clocker.docker.location.strategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import clocker.docker.entity.container.DockerContainer;
+import clocker.docker.location.DockerHostLocation;
+
 import com.google.common.annotations.Beta;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
@@ -26,9 +29,6 @@ import com.google.common.collect.Iterables;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.core.entity.EntityFunctions;
 import org.apache.brooklyn.core.entity.EntityPredicates;
-
-import brooklyn.entity.container.docker.DockerContainer;
-import brooklyn.location.docker.DockerHostLocation;
 
 /**
  * A number of {@link Predicate predicates} that check for properties of

--- a/docker/src/main/java/clocker/docker/location/strategy/basic/BreadthFirstPlacementStrategy.java
+++ b/docker/src/main/java/clocker/docker/location/strategy/basic/BreadthFirstPlacementStrategy.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package clocker.docker.location.strategy;
+package clocker.docker.location.strategy.basic;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import clocker.docker.location.DockerHostLocation;
+import clocker.docker.location.strategy.AbstractDockerPlacementStrategy;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;

--- a/docker/src/main/java/clocker/docker/location/strategy/basic/DepthFirstPlacementStrategy.java
+++ b/docker/src/main/java/clocker/docker/location/strategy/basic/DepthFirstPlacementStrategy.java
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package clocker.docker.location.strategy;
+package clocker.docker.location.strategy.basic;
 
 import clocker.docker.location.DockerHostLocation;
+import clocker.docker.location.strategy.BasicDockerPlacementStrategy;
 
 import com.google.common.collect.Ordering;
 

--- a/docker/src/main/java/clocker/docker/location/strategy/basic/GroupPlacementStrategy.java
+++ b/docker/src/main/java/clocker/docker/location/strategy/basic/GroupPlacementStrategy.java
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package clocker.docker.location.strategy;
+package clocker.docker.location.strategy.basic;
 
-import static clocker.docker.location.strategy.StrategyPredicates.childrenOf;
-import static clocker.docker.location.strategy.StrategyPredicates.hasApplicationId;
-import static clocker.docker.location.strategy.StrategyPredicates.nonEmpty;
+import static clocker.docker.location.strategy.util.StrategyPredicates.childrenOf;
+import static clocker.docker.location.strategy.util.StrategyPredicates.hasApplicationId;
+import static clocker.docker.location.strategy.util.StrategyPredicates.nonEmpty;
 
 import java.util.List;
 import java.util.Map;
@@ -29,6 +29,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import clocker.docker.location.DockerHostLocation;
+import clocker.docker.location.strategy.AbstractDockerPlacementStrategy;
+import clocker.docker.location.strategy.DockerAwarePlacementStrategy;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Optional;

--- a/docker/src/main/java/clocker/docker/location/strategy/basic/HostnamePlacementStrategy.java
+++ b/docker/src/main/java/clocker/docker/location/strategy/basic/HostnamePlacementStrategy.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package clocker.docker.location.strategy;
+package clocker.docker.location.strategy.basic;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import clocker.docker.location.DockerHostLocation;
+import clocker.docker.location.strategy.BasicDockerPlacementStrategy;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;

--- a/docker/src/main/java/clocker/docker/location/strategy/basic/LabelPlacementStrategy.java
+++ b/docker/src/main/java/clocker/docker/location/strategy/basic/LabelPlacementStrategy.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package clocker.docker.location.strategy;
+package clocker.docker.location.strategy.basic;
 
 import java.util.List;
 import java.util.Set;
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import clocker.docker.location.DockerHostLocation;
+import clocker.docker.location.strategy.BasicDockerPlacementStrategy;
 
 import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableList;

--- a/docker/src/main/java/clocker/docker/location/strategy/basic/LeastContainersPlacementStrategy.java
+++ b/docker/src/main/java/clocker/docker/location/strategy/basic/LeastContainersPlacementStrategy.java
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package clocker.docker.location.strategy;
+package clocker.docker.location.strategy.basic;
 
 import clocker.docker.entity.DockerHost;
 import clocker.docker.location.DockerHostLocation;
+import clocker.docker.location.strategy.BasicDockerPlacementStrategy;
 
 import org.apache.brooklyn.entity.group.BasicGroup;
 

--- a/docker/src/main/java/clocker/docker/location/strategy/basic/LowestCpuUsagePlacementStrategy.java
+++ b/docker/src/main/java/clocker/docker/location/strategy/basic/LowestCpuUsagePlacementStrategy.java
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package clocker.docker.location.strategy;
+package clocker.docker.location.strategy.basic;
 
 import clocker.docker.entity.DockerHost;
 import clocker.docker.location.DockerHostLocation;
+import clocker.docker.location.strategy.BasicDockerPlacementStrategy;
 
 /**
  * Placement strategy that selects the Docker host with the lowest CPU usage.

--- a/docker/src/main/java/clocker/docker/location/strategy/basic/MaxContainersPlacementStrategy.java
+++ b/docker/src/main/java/clocker/docker/location/strategy/basic/MaxContainersPlacementStrategy.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package clocker.docker.location.strategy;
+package clocker.docker.location.strategy.basic;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import clocker.docker.entity.DockerHost;
 import clocker.docker.entity.DockerInfrastructure;
 import clocker.docker.location.DockerHostLocation;
+import clocker.docker.location.strategy.BasicDockerPlacementStrategy;
 
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;

--- a/docker/src/main/java/clocker/docker/location/strategy/basic/MaxCpuUsagePlacementStrategy.java
+++ b/docker/src/main/java/clocker/docker/location/strategy/basic/MaxCpuUsagePlacementStrategy.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package clocker.docker.location.strategy;
+package clocker.docker.location.strategy.basic;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import clocker.docker.entity.DockerHost;
 import clocker.docker.entity.DockerInfrastructure;
 import clocker.docker.location.DockerHostLocation;
+import clocker.docker.location.strategy.BasicDockerPlacementStrategy;
 
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;

--- a/docker/src/main/java/clocker/docker/location/strategy/basic/RandomPlacementStrategy.java
+++ b/docker/src/main/java/clocker/docker/location/strategy/basic/RandomPlacementStrategy.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package clocker.docker.location.strategy;
+package clocker.docker.location.strategy.basic;
 
 import java.util.Collections;
 import java.util.List;
 
 import clocker.docker.location.DockerHostLocation;
+import clocker.docker.location.strategy.AbstractDockerPlacementStrategy;
 
 import com.google.common.collect.ImmutableList;
 

--- a/docker/src/main/java/clocker/docker/location/strategy/host/ProvisioningFlagsPlacementStrategy.java
+++ b/docker/src/main/java/clocker/docker/location/strategy/host/ProvisioningFlagsPlacementStrategy.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package clocker.docker.location.strategy;
+package clocker.docker.location.strategy.host;
 
 import java.util.List;
 import java.util.Map;
@@ -22,6 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import clocker.docker.location.DockerHostLocation;
+import clocker.docker.location.strategy.AbstractDockerPlacementStrategy;
+import clocker.docker.location.strategy.DockerAwareProvisioningStrategy;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
@@ -36,7 +38,8 @@ import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
 
 /**
- * Placement strategy that selects the Docker host with the lowest CPU usage.
+ * Placement strategy that selects the Docker host with appropriate properties, or
+ * configures the flags for provisioning a new host.
  */
 public class ProvisioningFlagsPlacementStrategy extends AbstractDockerPlacementStrategy implements DockerAwareProvisioningStrategy {
 

--- a/docker/src/main/java/clocker/docker/location/strategy/util/StrategyPredicates.java
+++ b/docker/src/main/java/clocker/docker/location/strategy/util/StrategyPredicates.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package clocker.docker.location.strategy;
+package clocker.docker.location.strategy.util;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/SdnProvider.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/SdnProvider.java
@@ -46,9 +46,6 @@ public interface SdnProvider extends BasicStartable, NetworkProvisioningExtensio
 
     AttributeSensor<Integer> ALLOCATED_NETWORKS = Sensors.newIntegerSensor("sdn.networks.allocated", "Number of allocated networks");
 
-    @SetFromFlag("vlanId")
-    AttributeSensorAndConfigKey<Integer, Integer> VLAN_ID = ConfigKeys.newIntegerSensorAndConfigKey("sdn.softlayer.vlanId", "Softlayer VLAN ID");
-
     AttributeSensor<Map<String, Cidr>> SUBNETS = Sensors.newSensor(
             new TypeToken<Map<String, Cidr>>() { }, "sdn.networks.addresses", "Map of network subnets that have been created");
     AttributeSensor<Map<String, VirtualNetwork>> SUBNET_ENTITIES = Sensors.newSensor(

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/calico/CalicoNodeSshDriver.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/calico/CalicoNodeSshDriver.java
@@ -166,7 +166,8 @@ public class CalicoNodeSshDriver extends AbstractSoftwareProcessSshDriver implem
             newScript("addCalico")
                     .body.append( // Idempotent
                             sudo(String.format("%s profile add %s", getCalicoCommand(), subnetId)),
-                            sudo(String.format("%s endpoint %s profile append %s", getCalicoCommand(), endpointId, subnetId)))
+                            sudo(String.format("%s endpoint %s profile append %s --host=%s --orchestrator=brooklyn-clocker",
+                                    getCalicoCommand(), endpointId, subnetId, agentAddress.getHostAddress())))
                     .execute();
 
             // Find router for eth1
@@ -184,7 +185,7 @@ public class CalicoNodeSshDriver extends AbstractSoftwareProcessSshDriver implem
             newScript("addRoutes")
                     .body.append(
                             sudo(String.format("ip netns exec %s ip route add default via %s", dockerPid, dockerIp)),
-                            sudo(String.format("ip netns exec %s ip route add %s via %s", dockerPid, subnetCidr.toString(), agentAddress.getHostAddress())))
+                            sudo(String.format("ip netns exec %s ip route add %s via %s", dockerPid, subnetCidr.toString(), routerAddress)))
                     .execute();
         } else {
             // Add extra network address

--- a/docker/src/main/java/clocker/docker/policy/ContainerHeadroomEnricher.java
+++ b/docker/src/main/java/clocker/docker/policy/ContainerHeadroomEnricher.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import clocker.docker.entity.DockerInfrastructure;
 import clocker.docker.location.strategy.DockerAwarePlacementStrategy;
-import clocker.docker.location.strategy.MaxContainersPlacementStrategy;
+import clocker.docker.location.strategy.basic.MaxContainersPlacementStrategy;
 import clocker.docker.policy.ContainerHeadroomEnricher;
 
 import com.google.common.base.Optional;
@@ -89,9 +89,10 @@ public class ContainerHeadroomEnricher extends AbstractEnricher {
     static {
         RendererHints.register(DOCKER_CONTAINER_UTILISATION, RendererHints.displayValue(MathFunctions.percent(3)));
     }
-    
+
     private BasicNotificationSensor lastPublished = null;
 
+    @Override
     public void setEntity(EntityLocal entity) {
         Preconditions.checkArgument(entity instanceof DockerInfrastructure, "Entity must be a DockerInfrastructure: %s", entity);
         super.setEntity(entity);
@@ -155,10 +156,10 @@ public class ContainerHeadroomEnricher extends AbstractEnricher {
 
         double lowThreshold = (double) (possible - (headroom + maxContainers)) / (double) possible;
         lowThreshold = Math.max(0d, lowThreshold);
-        
+
         double highThreshold = (double) (possible - headroom) / (double) possible;
         highThreshold = Math.max(0, highThreshold);
-        
+
         // Emit current status of the pool as sensor data
         emit(CONTAINERS_NEEDED, needed);
         emit(DOCKER_CONTAINER_UTILISATION, utilisation);

--- a/docker/src/test/java/clocker/docker/policy/ContainerHeadroomEnricherTest.java
+++ b/docker/src/test/java/clocker/docker/policy/ContainerHeadroomEnricherTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 
 import clocker.docker.entity.DockerInfrastructure;
 import clocker.docker.location.DockerLocation;
-import clocker.docker.location.strategy.MaxContainersPlacementStrategy;
+import clocker.docker.location.strategy.basic.MaxContainersPlacementStrategy;
 import clocker.docker.policy.ContainerHeadroomEnricher;
 
 import com.google.common.collect.ImmutableList;

--- a/extras/src/main/java/org/apache/brooklyn/entity/nosql/etcd/EtcdCluster.java
+++ b/extras/src/main/java/org/apache/brooklyn/entity/nosql/etcd/EtcdCluster.java
@@ -27,10 +27,12 @@ import org.apache.brooklyn.api.entity.ImplementedBy;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.entity.group.DynamicCluster;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
+import org.apache.brooklyn.util.time.Duration;
 
 @Catalog(name="Etcd Cluster", description="Etcd is an open-source distributed key-value store that serves as "
         + "the backbone of distributed systems by providing a canonical hub for cluster coordination and state management.")
@@ -41,6 +43,9 @@ public interface EtcdCluster extends DynamicCluster {
     AttributeSensor<Map<Entity, String>> ETCD_CLUSTER_NODES = Sensors.newSensor(
             new TypeToken<Map<Entity, String>>() {}, 
             "etcd.cluster.nodes", "Names of all active etcd nodes in the cluster (entity reference to name mapping)");
+
+    @SetFromFlag("startTimeout")
+    ConfigKey<Duration> START_TIMEOUT = ConfigKeys.newConfigKeyWithDefault(BrooklynConfigKeys.START_TIMEOUT, Duration.minutes(10));
 
     @SetFromFlag("clusterName")
     ConfigKey<String> CLUSTER_NAME = ConfigKeys.newStringConfigKey("etcd.cluster.name", "The Etcd cluster name", "brooklyn");

--- a/extras/src/main/java/org/apache/brooklyn/entity/nosql/etcd/EtcdNode.java
+++ b/extras/src/main/java/org/apache/brooklyn/entity/nosql/etcd/EtcdNode.java
@@ -24,6 +24,7 @@ import org.apache.brooklyn.core.annotation.Effector;
 import org.apache.brooklyn.core.annotation.EffectorParam;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.effector.MethodEffector;
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.location.PortRanges;
 import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensorAndConfigKey;
@@ -31,6 +32,7 @@ import org.apache.brooklyn.core.sensor.PortAttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
+import org.apache.brooklyn.util.time.Duration;
 
 @Catalog(name="Etcd Node")
 @ImplementedBy(EtcdNodeImpl.class)
@@ -39,9 +41,15 @@ public interface EtcdNode extends SoftwareProcess {
     @SetFromFlag("version")
     ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "2.0.11");
 
+    @SetFromFlag("startTimeout")
+    ConfigKey<Duration> START_TIMEOUT = ConfigKeys.newConfigKeyWithDefault(BrooklynConfigKeys.START_TIMEOUT, Duration.minutes(10));
+
     @SetFromFlag("downloadUrl")
     AttributeSensorAndConfigKey<String, String> DOWNLOAD_URL = new BasicAttributeSensorAndConfigKey<String>(
             SoftwareProcess.DOWNLOAD_URL, "https://github.com/coreos/etcd/releases/download/v${version}/etcd-v${version}-linux-amd64.tar.gz");
+
+    @SetFromFlag("archiveNameFormat")
+    ConfigKey<String> ARCHIVE_DIRECTORY_NAME_FORMAT = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.ARCHIVE_DIRECTORY_NAME_FORMAT, "etcd-v%s-linux-amd64");
 
     @SetFromFlag("etcdClientPort")
     PortAttributeSensorAndConfigKey ETCD_CLIENT_PORT = new PortAttributeSensorAndConfigKey("etcd.port.client", "Etcd client port", PortRanges.fromInteger(2379));

--- a/extras/src/main/java/org/apache/brooklyn/entity/nosql/etcd/EtcdProxy.java
+++ b/extras/src/main/java/org/apache/brooklyn/entity/nosql/etcd/EtcdProxy.java
@@ -17,11 +17,14 @@ package org.apache.brooklyn.entity.nosql.etcd;
 
 import org.apache.brooklyn.api.catalog.Catalog;
 import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.location.PortRanges;
 import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.PortAttributeSensorAndConfigKey;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
+import org.apache.brooklyn.util.time.Duration;
 
 @Catalog(name="Etcd Proxy")
 @ImplementedBy(EtcdProxyImpl.class)
@@ -29,6 +32,9 @@ public interface EtcdProxy extends EtcdNode {
 
     @SetFromFlag("etcdClientPort")
     PortAttributeSensorAndConfigKey ETCD_CLIENT_PORT = new PortAttributeSensorAndConfigKey("etcd.port.client", "Etcd proxy client port", PortRanges.fromInteger(4001));
+
+    @SetFromFlag("startTimeout")
+    ConfigKey<Duration> START_TIMEOUT = ConfigKeys.newConfigKeyWithDefault(BrooklynConfigKeys.START_TIMEOUT, Duration.minutes(10));
 
     AttributeSensorAndConfigKey<String, String> ETCD_CLUSTER_URL = ConfigKeys.newStringSensorAndConfigKey("etcd.cluster.url", "Returns the Etcd cluster URL");
     AttributeSensorAndConfigKey<String, String> ETCD_CLUSTER_NAME = ConfigKeys.newStringSensorAndConfigKey("etcd.cluster.name", "Returns the Etcd cluster name");

--- a/jsgui/pom.xml
+++ b/jsgui/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>brooklyn-clocker-jsgui</artifactId>
 
-    <name>Brooklyn Clocker  REST JavaScript Web GUI</name>
+    <name>Clocker REST JavaScript Web GUI</name>
 
     <description>
         JavaScript+HTML GUI for interacting with clocker, building on Brooklyn JS GUI and using the Brooklyn REST API

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,3 +1,11 @@
+Clocker Patches
+===============
+
+This project contains files that have been changed in external projects but
+are not yet available in public repositories for donload as dependencies.
+
+# Current Patch Files
+
 ## Fix NPE in forcePersistNow
 
 Fixes issue where `forcePeristNow()` fails due to `persistenceRealChangeListener`
@@ -11,3 +19,20 @@ for full code changes.
 This code is part of brooklyn-server _0.10.0-SNAPSHOT_ but **not** any official
 Brooklyn release yet.
 
+## Added volumesFrom to Docker template options
+
+This adds the `VolumesFrom` configuration to the API request to create a
+container. This is the same as the `--volumes-from` command line option for
+`docker run`.
+
+See [jclouds/jclouds-labs#253](https://github.com/jclouds/jclouds-labs/pull/253)
+for full code changes.
+
+- [`DockerTemplateOptions.java`](./src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java)
+- [`DockerComputeServiceAdapter.java`](./src/main/java/org/jclouds/docker/compute/strategy/DockerComputeServiceAdapter.java)
+- [`Config.java`](./src/main/java/org/jclouds/docker/domain/Config.java)
+- [`HostConfig.java`](./src/main/java/org/jclouds/docker/domain/HostConfig.java)
+- [`NullSafeCopies.java`](./src/main/java/org/jclouds/docker/internal/NullSafeCopies.java)
+
+This code is part of jclouds-labs _1.9.3-SNAPSHOT_ and _2.0.0-SNAPSHOT_
+but **not** any official jclouds release yet.

--- a/patches/src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java
+++ b/patches/src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java
@@ -51,15 +51,15 @@ import org.jclouds.scriptbuilder.domain.Statement;
 public class DockerTemplateOptions extends TemplateOptions implements Cloneable {
 
    protected List<String> dns = ImmutableList.of();
-   protected String hostname;
-   protected Integer memory;
-   protected Integer cpuShares;
-   protected List<String> entrypoint = ImmutableList.of();
-   protected List<String> commands = ImmutableList.of();
+   @Nullable protected String hostname;
+   @Nullable protected Integer memory;
+   @Nullable protected Integer cpuShares;
+   @Nullable List<String> entrypoint;
+   @Nullable List<String> commands;
    protected Map<String, String> volumes = ImmutableMap.of();
-   protected List<String> env = ImmutableList.of();
+   @Nullable protected List<String> env;
    protected Map<Integer, Integer> portBindings = ImmutableMap.of();
-   protected String networkMode;
+   @Nullable protected String networkMode;
    protected Map<String, String> extraHosts = ImmutableMap.of();
    protected List<String> volumesFrom = ImmutableList.of();
 
@@ -138,12 +138,12 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
    }
 
    public DockerTemplateOptions dns(Iterable<String> dns) {
-      this.dns = NullSafeCopies.copyWithNullOf(dns);
+      this.dns = NullSafeCopies.copyOf(dns);
       return this;
    }
 
    public DockerTemplateOptions dns(String...dns) {
-      this.dns = NullSafeCopies.copyWithNullOf(dns);
+      this.dns = NullSafeCopies.copyOf(dns);
       return this;
    }
 
@@ -227,7 +227,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
     * @param extraHosts the map of host names to IP addresses
     */
    public DockerTemplateOptions extraHosts(Map<String, String> extraHosts) {
-      this.extraHosts = NullSafeCopies.copyWithNullOf(extraHosts);
+      this.extraHosts = NullSafeCopies.copyOf(extraHosts);
       return this;
    }
 
@@ -237,7 +237,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
     * @param volumesFrom the list of container names
     */
    public DockerTemplateOptions volumesFrom(Iterable<String> volumesFrom) {
-      this.volumesFrom = NullSafeCopies.copyWithNullOf(volumesFrom);
+      this.volumesFrom = NullSafeCopies.copyOf(volumesFrom);
       return this;
    }
 

--- a/patches/src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java
+++ b/patches/src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java
@@ -1,0 +1,650 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.docker.compute.options;
+
+import static com.google.common.base.Objects.equal;
+
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import org.jclouds.compute.ComputeService;
+import org.jclouds.compute.options.TemplateOptions;
+import org.jclouds.docker.internal.NullSafeCopies;
+import org.jclouds.domain.LoginCredentials;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.scriptbuilder.domain.Statement;
+
+/**
+ * Contains options supported by the {@link ComputeService#createNodesInGroup(String, int, TemplateOptions) createNodes}
+ * operation on the <em>docker</em> provider.
+ *
+ * <h2>Usage</h2>
+ *
+ * The recommended way to instantiate a
+ * DockerTemplateOptions object is to statically import {@code DockerTemplateOptions.Builder.*}
+ * and invoke one of the static creation methods, followed by an instance mutator if needed.
+ *
+ * <pre>{@code import static org.jclouds.docker.compute.options.DockerTemplateOptions.Builder.*;
+ *
+ * ComputeService api = // get connection
+ * templateBuilder.options(inboundPorts(22, 80, 8080, 443));
+ * Set<? extends NodeMetadata> set = api.createNodesInGroup(tag, 2, templateBuilder.build());}</pre>
+ */
+public class DockerTemplateOptions extends TemplateOptions implements Cloneable {
+
+   protected List<String> dns = ImmutableList.of();
+   protected String hostname;
+   protected Integer memory;
+   protected Integer cpuShares;
+   protected List<String> entrypoint = ImmutableList.of();
+   protected List<String> commands = ImmutableList.of();
+   protected Map<String, String> volumes = ImmutableMap.of();
+   protected List<String> env = ImmutableList.of();
+   protected Map<Integer, Integer> portBindings = ImmutableMap.of();
+   protected String networkMode;
+   protected Map<String, String> extraHosts = ImmutableMap.of();
+   protected List<String> volumesFrom = ImmutableList.of();
+
+   @Override
+   public DockerTemplateOptions clone() {
+      DockerTemplateOptions options = new DockerTemplateOptions();
+      copyTo(options);
+      return options;
+   }
+
+   @Override
+   public void copyTo(TemplateOptions to) {
+      super.copyTo(to);
+      if (to instanceof DockerTemplateOptions) {
+         DockerTemplateOptions eTo = DockerTemplateOptions.class.cast(to);
+         eTo.volumes(volumes);
+         eTo.hostname(hostname);
+         eTo.dns(dns);
+         eTo.memory(memory);
+         eTo.cpuShares(cpuShares);
+         eTo.entrypoint(entrypoint);
+         eTo.commands(commands);
+         eTo.env(env);
+         eTo.portBindings(portBindings);
+         eTo.networkMode(networkMode);
+         eTo.extraHosts(extraHosts);
+         eTo.volumesFrom(volumesFrom);
+      }
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o)
+         return true;
+      if (o == null || getClass() != o.getClass())
+         return false;
+      DockerTemplateOptions that = DockerTemplateOptions.class.cast(o);
+      return super.equals(that) && equal(this.volumes, that.volumes) &&
+              equal(this.hostname, that.hostname) &&
+              equal(this.dns, that.dns) &&
+              equal(this.memory, that.memory) &&
+              equal(this.entrypoint, that.entrypoint) &&
+              equal(this.commands, that.commands) &&
+              equal(this.cpuShares, that.cpuShares) &&
+              equal(this.env, that.env) &&
+              equal(this.portBindings, that.portBindings) &&
+              equal(this.extraHosts, that.extraHosts) &&
+              equal(this.volumesFrom, that.volumesFrom);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hashCode(super.hashCode(), volumes, hostname, dns, memory, entrypoint, commands, cpuShares, env, portBindings, extraHosts);
+   }
+
+   @Override
+   public String toString() {
+      return Objects.toStringHelper(this)
+              .add("dns", dns)
+              .add("hostname", hostname)
+              .add("memory", memory)
+              .add("cpuShares", cpuShares)
+              .add("entrypoint", entrypoint)
+              .add("commands", commands)
+              .add("volumes", volumes)
+              .add("env", env)
+              .add("portBindings", portBindings)
+              .add("extraHosts", extraHosts)
+              .add("volumesFrom", volumesFrom)
+              .toString();
+   }
+
+   public DockerTemplateOptions volumes(Map<String, String> volumes) {
+      this.volumes = NullSafeCopies.copyOf(volumes);
+      return this;
+   }
+
+   public DockerTemplateOptions dns(Iterable<String> dns) {
+      this.dns = NullSafeCopies.copyWithNullOf(dns);
+      return this;
+   }
+
+   public DockerTemplateOptions dns(String...dns) {
+      this.dns = NullSafeCopies.copyWithNullOf(dns);
+      return this;
+   }
+
+   public DockerTemplateOptions hostname(@Nullable String hostname) {
+      this.hostname = hostname;
+      return this;
+   }
+
+   public DockerTemplateOptions memory(@Nullable Integer memory) {
+      this.memory = memory;
+      return this;
+   }
+
+   public DockerTemplateOptions entrypoint(Iterable<String> entrypoint) {
+      this.entrypoint = NullSafeCopies.copyWithNullOf(entrypoint);
+      return this;
+   }
+
+   public DockerTemplateOptions entrypoint(String... entrypoint) {
+      this.entrypoint = NullSafeCopies.copyWithNullOf(entrypoint);
+      return this;
+   }
+
+   public DockerTemplateOptions commands(Iterable<String> commands) {
+      this.commands = NullSafeCopies.copyWithNullOf(commands);
+      return this;
+   }
+
+   public DockerTemplateOptions commands(String...commands) {
+      this.commands = NullSafeCopies.copyWithNullOf(commands);
+      return this;
+   }
+
+   public DockerTemplateOptions cpuShares(@Nullable Integer cpuShares) {
+      this.cpuShares = cpuShares;
+      return this;
+   }
+
+   public DockerTemplateOptions env(Iterable<String> env) {
+      this.env = NullSafeCopies.copyWithNullOf(env);
+      return this;
+   }
+
+   public DockerTemplateOptions env(String...env) {
+      this.env = NullSafeCopies.copyWithNullOf(env);
+      return this;
+   }
+
+   /**
+    * Set port bindings between the Docker host and a container.
+    * <p>
+    * The {@link Map} keys are host ports number, and the value for an entry is the
+    * container port number. This is the same order as the arguments for the
+    * {@code --publish} command-line option to {@code docker run} which is
+    * {@code hostPort:containerPort}.
+    *
+    * @param portBindings the map of host to container port bindings
+    */
+   public DockerTemplateOptions portBindings(Map<Integer, Integer> portBindings) {
+      this.portBindings = NullSafeCopies.copyOf(portBindings);
+      return this;
+   }
+
+   /**
+    * Sets the networking mode for the container. Supported values are: bridge, host, and container:[name|id]
+    * @param networkMode
+    * @return this instance
+    */
+   public DockerTemplateOptions networkMode(@Nullable String networkMode) {
+      this.networkMode = networkMode;
+      return this;
+   }
+
+   /**
+    * Set extra hosts file entries for a container.
+    * <p>
+    * The {@link Map} keys are host names, and the value is an IP address that
+    * can be accessed by the container. This is the same order as the arguments for the
+    * {@code --add-host} command-line option to {@code docker run}.
+    *
+    * @param extraHosts the map of host names to IP addresses
+    */
+   public DockerTemplateOptions extraHosts(Map<String, String> extraHosts) {
+      this.extraHosts = NullSafeCopies.copyWithNullOf(extraHosts);
+      return this;
+   }
+
+   /**
+    * Set list of containers to mount volumes from onto this container.
+    *
+    * @param volumesFrom the list of container names
+    */
+   public DockerTemplateOptions volumesFrom(Iterable<String> volumesFrom) {
+      this.volumesFrom = NullSafeCopies.copyWithNullOf(volumesFrom);
+      return this;
+   }
+
+   public Map<String, String> getVolumes() { return volumes; }
+
+   public List<String> getDns() { return dns; }
+
+   public List<String> getVolumesFrom() { return volumesFrom; }
+
+   public String getHostname() { return hostname; }
+
+   public Integer getMemory() { return memory; }
+
+   public List<String> getEntrypoint() { return entrypoint; }
+
+   public List<String> getCommands() { return commands; }
+
+   public Integer getCpuShares() { return cpuShares; }
+
+   public List<String> getEnv() { return env; }
+
+   public Map<Integer, Integer> getPortBindings() { return portBindings; }
+
+   public String getNetworkMode() { return networkMode; }
+
+   public Map<String, String> getExtraHosts() { return extraHosts; }
+
+   public static class Builder {
+
+      /**
+       * @see DockerTemplateOptions#volumes(Map)
+       */
+      public static DockerTemplateOptions volumes(Map<String, String> volumes) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.volumes(volumes);
+      }
+
+      /**
+       * @see DockerTemplateOptions#dns(String...)
+       */
+      public static DockerTemplateOptions dns(String...dns) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.dns(dns);
+      }
+
+      /**
+       * @see DockerTemplateOptions#dns(List)
+       */
+      public static DockerTemplateOptions dns(Iterable<String> dns) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.dns(dns);
+      }
+
+      /**
+       * @see DockerTemplateOptions#hostname(String)
+       */
+      public static DockerTemplateOptions hostname(@Nullable String hostname) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.hostname(hostname);
+      }
+
+      /**
+       * @see DockerTemplateOptions#memory(Integer)
+       */
+      public static DockerTemplateOptions memory(@Nullable Integer memory) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.memory(memory);
+      }
+
+      /**
+       * @see DockerTemplateOptions#entrypoint(String...)
+       */
+      public static DockerTemplateOptions entrypoint(String...entrypoint) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.entrypoint(entrypoint);
+      }
+
+      /**
+       * @see DockerTemplateOptions#entrypoint(Iterable)
+       */
+      public static DockerTemplateOptions entrypoint(Iterable<String> entrypoint) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.entrypoint(entrypoint);
+      }
+
+      /**
+       * @see DockerTemplateOptions#commands(String...)
+       */
+      public static DockerTemplateOptions commands(String...commands) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.commands(commands);
+      }
+
+      /**
+       * @see DockerTemplateOptions#commands(Iterable)
+       */
+      public static DockerTemplateOptions commands(Iterable<String> commands) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.commands(commands);
+      }
+
+      /**
+       * @see DockerTemplateOptions#cpuShares(Integer)
+       */
+      public static DockerTemplateOptions cpuShares(@Nullable Integer cpuShares) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.cpuShares(cpuShares);
+      }
+
+      /**
+       * @see DockerTemplateOptions#env(String...)
+       */
+      public static DockerTemplateOptions env(String...env) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.env(env);
+      }
+
+      /**
+       * @see DockerTemplateOptions#env(Iterable)
+       */
+      public static DockerTemplateOptions env(Iterable<String> env) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.env(env);
+      }
+
+      /**
+       * @see DockerTemplateOptions#portBindings(Map)
+       */
+      public static DockerTemplateOptions portBindings(Map<Integer, Integer> portBindings) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.portBindings(portBindings);
+      }
+
+      /**
+       * @see DockerTemplateOptions#networkMode(String)
+       */
+      public static DockerTemplateOptions networkMode(@Nullable String networkMode) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.networkMode(networkMode);
+      }
+
+      /**
+       * @see DockerTemplateOptions#extraHosts(Map)
+       */
+      public static DockerTemplateOptions extraHosts(Map<String, String> extraHosts) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.extraHosts(extraHosts);
+      }
+
+      /**
+       * @see DockerTemplateOptions#volumesFrom(Iterable)
+       */
+      public static DockerTemplateOptions volumesFrom(Iterable<String> volumesFrom) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.volumesFrom(volumesFrom);
+      }
+
+      /**
+       * @see TemplateOptions#inboundPorts(int...)
+       */
+      public static DockerTemplateOptions inboundPorts(int... ports) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.inboundPorts(ports);
+      }
+
+      /**
+       * @see TemplateOptions#blockOnPort(int, int)
+       */
+      public static DockerTemplateOptions blockOnPort(int port, int seconds) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.blockOnPort(port, seconds);
+      }
+
+      /**
+       * @see TemplateOptions#installPrivateKey(String)
+       */
+      public static DockerTemplateOptions installPrivateKey(String rsaKey) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.installPrivateKey(rsaKey);
+      }
+
+      /**
+       * @see TemplateOptions#authorizePublicKey(String)
+       */
+      public static DockerTemplateOptions authorizePublicKey(String rsaKey) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.authorizePublicKey(rsaKey);
+      }
+
+      /**
+       * @see TemplateOptions#userMetadata(Map)
+       */
+      public static DockerTemplateOptions userMetadata(Map<String, String> userMetadata) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.userMetadata(userMetadata);
+      }
+
+      /**
+       * @see TemplateOptions#nodeNames(Iterable)
+       */
+      public static DockerTemplateOptions nodeNames(Iterable<String> nodeNames) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.nodeNames(nodeNames);
+      }
+
+      /**
+       * @see TemplateOptions#networks(Iterable)
+       */
+      public static DockerTemplateOptions networks(Iterable<String> networks) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.networks(networks);
+      }
+
+      /**
+       * @see TemplateOptions#overrideLoginUser(String)
+       */
+      public static DockerTemplateOptions overrideLoginUser(String user) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.overrideLoginUser(user);
+      }
+
+      /**
+       * @see TemplateOptions#overrideLoginPassword(String)
+       */
+      public static DockerTemplateOptions overrideLoginPassword(String password) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.overrideLoginPassword(password);
+      }
+
+      /**
+       * @see TemplateOptions#overrideLoginPrivateKey(String)
+       */
+      public static DockerTemplateOptions overrideLoginPrivateKey(String privateKey) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.overrideLoginPrivateKey(privateKey);
+      }
+
+      /**
+       * @see TemplateOptions#overrideAuthenticateSudo(boolean)
+       */
+      public static DockerTemplateOptions overrideAuthenticateSudo(boolean authenticateSudo) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.overrideAuthenticateSudo(authenticateSudo);
+      }
+
+      /**
+       * @see TemplateOptions#overrideLoginCredentials(LoginCredentials)
+       */
+      public static DockerTemplateOptions overrideLoginCredentials(LoginCredentials credentials) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.overrideLoginCredentials(credentials);
+      }
+
+      /**
+       * @see TemplateOptions#blockUntilRunning(boolean)
+       */
+      public static DockerTemplateOptions blockUntilRunning(boolean blockUntilRunning) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.blockUntilRunning(blockUntilRunning);
+      }
+
+   }
+
+   // methods that only facilitate returning the correct object type
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public DockerTemplateOptions blockOnPort(int port, int seconds) {
+      return DockerTemplateOptions.class.cast(super.blockOnPort(port, seconds));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public DockerTemplateOptions inboundPorts(int... ports) {
+      return DockerTemplateOptions.class.cast(super.inboundPorts(ports));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public DockerTemplateOptions authorizePublicKey(String publicKey) {
+      return DockerTemplateOptions.class.cast(super.authorizePublicKey(publicKey));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public DockerTemplateOptions installPrivateKey(String privateKey) {
+      return DockerTemplateOptions.class.cast(super.installPrivateKey(privateKey));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public DockerTemplateOptions blockUntilRunning(boolean blockUntilRunning) {
+      return DockerTemplateOptions.class.cast(super.blockUntilRunning(blockUntilRunning));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public DockerTemplateOptions dontAuthorizePublicKey() {
+      return DockerTemplateOptions.class.cast(super.dontAuthorizePublicKey());
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public DockerTemplateOptions nameTask(String name) {
+      return DockerTemplateOptions.class.cast(super.nameTask(name));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public DockerTemplateOptions runAsRoot(boolean runAsRoot) {
+      return DockerTemplateOptions.class.cast(super.runAsRoot(runAsRoot));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public DockerTemplateOptions runScript(Statement script) {
+      return DockerTemplateOptions.class.cast(super.runScript(script));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public DockerTemplateOptions overrideLoginCredentials(LoginCredentials overridingCredentials) {
+      return DockerTemplateOptions.class.cast(super.overrideLoginCredentials(overridingCredentials));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public DockerTemplateOptions overrideLoginPassword(String password) {
+      return DockerTemplateOptions.class.cast(super.overrideLoginPassword(password));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public DockerTemplateOptions overrideLoginPrivateKey(String privateKey) {
+      return DockerTemplateOptions.class.cast(super.overrideLoginPrivateKey(privateKey));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public DockerTemplateOptions overrideLoginUser(String loginUser) {
+      return DockerTemplateOptions.class.cast(super.overrideLoginUser(loginUser));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public DockerTemplateOptions overrideAuthenticateSudo(boolean authenticateSudo) {
+      return DockerTemplateOptions.class.cast(super.overrideAuthenticateSudo(authenticateSudo));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public DockerTemplateOptions userMetadata(Map<String, String> userMetadata) {
+      return DockerTemplateOptions.class.cast(super.userMetadata(userMetadata));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public DockerTemplateOptions userMetadata(String key, String value) {
+      return DockerTemplateOptions.class.cast(super.userMetadata(key, value));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public DockerTemplateOptions nodeNames(Iterable<String> nodeNames) {
+      return DockerTemplateOptions.class.cast(super.nodeNames(nodeNames));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public DockerTemplateOptions networks(Iterable<String> networks) {
+      return DockerTemplateOptions.class.cast(super.networks(networks));
+   }
+
+}

--- a/patches/src/main/java/org/jclouds/docker/compute/strategy/DockerComputeServiceAdapter.java
+++ b/patches/src/main/java/org/jclouds/docker/compute/strategy/DockerComputeServiceAdapter.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.docker.compute.strategy;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Iterables.find;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Resource;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.jclouds.compute.ComputeServiceAdapter;
+import org.jclouds.compute.domain.Hardware;
+import org.jclouds.compute.domain.HardwareBuilder;
+import org.jclouds.compute.domain.Processor;
+import org.jclouds.compute.domain.Template;
+import org.jclouds.compute.reference.ComputeServiceConstants;
+import org.jclouds.docker.DockerApi;
+import org.jclouds.docker.compute.options.DockerTemplateOptions;
+import org.jclouds.docker.domain.Config;
+import org.jclouds.docker.domain.Container;
+import org.jclouds.docker.domain.ContainerSummary;
+import org.jclouds.docker.domain.HostConfig;
+import org.jclouds.docker.domain.Image;
+import org.jclouds.docker.domain.ImageSummary;
+import org.jclouds.docker.options.ListContainerOptions;
+import org.jclouds.docker.options.RemoveContainerOptions;
+import org.jclouds.domain.Location;
+import org.jclouds.domain.LoginCredentials;
+import org.jclouds.logging.Logger;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+/**
+ * defines the connection between the {@link org.jclouds.docker.DockerApi} implementation and
+ * the jclouds {@link org.jclouds.compute.ComputeService}
+ */
+@Singleton
+public class DockerComputeServiceAdapter implements
+        ComputeServiceAdapter<Container, Hardware, Image, Location> {
+
+   @Resource
+   @Named(ComputeServiceConstants.COMPUTE_LOGGER)
+   protected Logger logger = Logger.NULL;
+
+   private final DockerApi api;
+
+   @Inject
+   public DockerComputeServiceAdapter(DockerApi api) {
+      this.api = checkNotNull(api, "api");
+   }
+
+   @Override
+   public NodeAndInitialCredentials<Container> createNodeWithGroupEncodedIntoName(String group, String name,
+                                                                                  Template template) {
+      checkNotNull(template, "template was null");
+      checkNotNull(template.getOptions(), "template options was null");
+
+      String imageId = checkNotNull(template.getImage().getId(), "template image id must not be null");
+      String loginUser = template.getImage().getDefaultCredentials().getUser();
+      String loginUserPassword = template.getImage().getDefaultCredentials().getOptionalPassword().or("password");
+
+      DockerTemplateOptions templateOptions = DockerTemplateOptions.class.cast(template.getOptions());
+      int[] inboundPorts = templateOptions.getInboundPorts();
+
+      Map<String, Object> exposedPorts = Maps.newHashMap();
+      for (int inboundPort : inboundPorts) {
+         exposedPorts.put(inboundPort + "/tcp", Maps.newHashMap());
+      }
+
+      Config.Builder containerConfigBuilder = Config.builder()
+              .image(imageId)
+              .exposedPorts(exposedPorts);
+
+      containerConfigBuilder.entrypoint(templateOptions.getEntrypoint());
+      containerConfigBuilder.cmd(templateOptions.getCommands());
+      containerConfigBuilder.memory(templateOptions.getMemory());
+      containerConfigBuilder.hostname(templateOptions.getHostname());
+      containerConfigBuilder.cpuShares(templateOptions.getCpuShares());
+      containerConfigBuilder.env(templateOptions.getEnv());
+
+      if (!templateOptions.getVolumes().isEmpty()) {
+         Map<String, Object> volumes = Maps.newLinkedHashMap();
+         for (String containerDir : templateOptions.getVolumes().values()) {
+            volumes.put(containerDir, Maps.newHashMap());
+         }
+         containerConfigBuilder.volumes(volumes);
+      }
+
+      Config containerConfig = containerConfigBuilder.build();
+
+      logger.debug(">> creating new container with containerConfig(%s)", containerConfig);
+      Container container = api.getContainerApi().createContainer(name, containerConfig);
+      logger.trace("<< container(%s)", container.id());
+
+      HostConfig.Builder hostConfigBuilder = HostConfig.builder()
+              .publishAllPorts(true)
+              .privileged(true);
+
+      if (!templateOptions.getPortBindings().isEmpty()) {
+         Map<String, List<Map<String, String>>> portBindings = Maps.newHashMap();
+         for (Map.Entry<Integer, Integer> entry : templateOptions.getPortBindings().entrySet()) {
+            portBindings.put(entry.getValue() + "/tcp",
+                  Lists.<Map<String, String>>newArrayList(ImmutableMap.of("HostPort", Integer.toString(entry.getKey()))));
+         }
+         hostConfigBuilder.portBindings(portBindings);
+      }
+
+      if (!templateOptions.getDns().isEmpty()) {
+         hostConfigBuilder.dns(templateOptions.getDns());
+      }
+
+      if (!templateOptions.getExtraHosts().isEmpty()) {
+         List<String> extraHosts = Lists.newArrayList();
+         for (Map.Entry<String, String> entry : templateOptions.getExtraHosts().entrySet()) {
+            extraHosts.add(entry.getKey() + ":" + entry.getValue());
+         }
+         hostConfigBuilder.extraHosts(extraHosts);
+      }
+
+      if (!templateOptions.getVolumes().isEmpty()) {
+         for (Map.Entry<String, String> entry : templateOptions.getVolumes().entrySet()) {
+             hostConfigBuilder.binds(ImmutableList.of(entry.getKey() + ":" + entry.getValue()));
+         }
+      }
+
+      if (!templateOptions.getVolumesFrom().isEmpty()) {
+          hostConfigBuilder.volumesFrom(templateOptions.getVolumesFrom());
+      }
+
+      hostConfigBuilder.networkMode(templateOptions.getNetworkMode());
+
+      HostConfig hostConfig = hostConfigBuilder.build();
+
+      api.getContainerApi().startContainer(container.id(), hostConfig);
+      container = api.getContainerApi().inspectContainer(container.id());
+      if (container.state().exitCode() != 0) {
+         destroyNode(container.id());
+         throw new IllegalStateException(String.format("Container %s has not started correctly", container.id()));
+      }
+      return new NodeAndInitialCredentials(container, container.id(),
+              LoginCredentials.builder().user(loginUser).password(loginUserPassword).build());
+   }
+
+   @Override
+   public Iterable<Hardware> listHardwareProfiles() {
+      Set<Hardware> hardware = Sets.newLinkedHashSet();
+      // todo they are only placeholders at the moment
+      hardware.add(new HardwareBuilder().ids("micro").hypervisor("lxc").name("micro").processor(new Processor(1, 1)).ram(512).build());
+      hardware.add(new HardwareBuilder().ids("small").hypervisor("lxc").name("small").processor(new Processor(1, 1)).ram(1024).build());
+      hardware.add(new HardwareBuilder().ids("medium").hypervisor("lxc").name("medium").processor(new Processor(2, 1)).ram(2048).build());
+      hardware.add(new HardwareBuilder().ids("large").hypervisor("lxc").name("large").processor(new Processor(2, 1)).ram(3072).build());
+      return hardware;
+   }
+
+   /**
+    * Method based on {@link org.jclouds.docker.features.ImageApi#listImages()}. It retrieves additional
+    * information by inspecting each image.
+    *
+    * @see org.jclouds.compute.ComputeServiceAdapter#listImages()
+    */
+   @Override
+   public Set<Image> listImages() {
+      Set<Image> images = Sets.newHashSet();
+      for (ImageSummary imageSummary : api.getImageApi().listImages()) {
+         // less efficient than just listImages but returns richer json that needs repoTags coming from listImages
+         Image inspected = api.getImageApi().inspectImage(imageSummary.id());
+         inspected = Image.create(inspected.id(), inspected.author(), inspected.comment(), inspected.config(),
+                    inspected.containerConfig(), inspected.parent(), inspected.created(), inspected.container(),
+                 inspected.dockerVersion(), inspected.architecture(), inspected.os(), inspected.size(),
+                    inspected.virtualSize(), imageSummary.repoTags());
+         images.add(inspected);
+      }
+      return images;
+   }
+
+   @Override
+   public Image getImage(final String imageId) {
+      // less efficient than just inspectImage but listImages return repoTags
+      return find(listImages(), new Predicate<Image>() {
+
+         @Override
+         public boolean apply(Image input) {
+            return input.id().equals(imageId);
+         }
+      }, null);
+   }
+
+   @Override
+   public Iterable<Container> listNodes() {
+      Set<Container> containers = Sets.newHashSet();
+      for (ContainerSummary containerSummary : api.getContainerApi().listContainers(ListContainerOptions.Builder.all(true))) {
+         // less efficient than just listNodes but returns richer json
+         containers.add(api.getContainerApi().inspectContainer(containerSummary.id()));
+      }
+      return containers;
+   }
+
+   @Override
+   public Iterable<Container> listNodesByIds(final Iterable<String> ids) {
+      Set<Container> containers = Sets.newHashSet();
+      for (String id : ids) {
+         containers.add(api.getContainerApi().inspectContainer(id));
+      }
+      return containers;
+   }
+
+   @Override
+   public Iterable<Location> listLocations() {
+      return ImmutableSet.of();
+   }
+
+   @Override
+   public Container getNode(String id) {
+      return api.getContainerApi().inspectContainer(id);
+   }
+
+   @Override
+   public void destroyNode(String id) {
+      api.getContainerApi().removeContainer(id, RemoveContainerOptions.Builder.force(true));
+   }
+
+   @Override
+   public void rebootNode(String id) {
+      api.getContainerApi().stopContainer(id);
+      api.getContainerApi().startContainer(id);
+   }
+
+   @Override
+   public void resumeNode(String id) {
+      api.getContainerApi().unpause(id);
+   }
+
+   @Override
+   public void suspendNode(String id) {
+      api.getContainerApi().pause(id);
+   }
+
+}

--- a/patches/src/main/java/org/jclouds/docker/domain/Config.java
+++ b/patches/src/main/java/org/jclouds/docker/domain/Config.java
@@ -1,0 +1,371 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.docker.domain;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.jclouds.docker.internal.NullSafeCopies.copyOf;
+import static org.jclouds.docker.internal.NullSafeCopies.copyWithNullOf;
+
+import java.util.List;
+import java.util.Map;
+
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+@AutoValue
+public abstract class Config {
+   @Nullable public abstract String hostname();
+
+   @Nullable public abstract String domainname();
+
+   @Nullable public abstract String user();
+
+   public abstract int memory();
+
+   public abstract int memorySwap();
+
+   public abstract int cpuShares();
+
+   public abstract boolean attachStdin();
+
+   public abstract boolean attachStdout();
+
+   public abstract boolean attachStderr();
+
+   public abstract boolean tty();
+
+   public abstract boolean openStdin();
+
+   public abstract boolean stdinOnce();
+
+   @Nullable public abstract List<String> env();
+
+   @Nullable public abstract List<String> cmd();
+
+   @Nullable public abstract List<String> entrypoint();
+
+   public abstract String image();
+
+   @Nullable public abstract Map<String, ?> volumes();
+
+   @Nullable public abstract String workingDir();
+
+   public abstract boolean networkDisabled();
+
+   public abstract Map<String, ?> exposedPorts();
+
+   public abstract List<String> securityOpts();
+
+   @Nullable public abstract HostConfig hostConfig();
+
+   @Nullable public abstract List<String> binds();
+
+   @Nullable public abstract List<String> links();
+
+   public abstract List<Map<String, String>> lxcConf();
+
+   public abstract Map<String, List<Map<String, String>>> portBindings();
+
+   public abstract boolean publishAllPorts();
+
+   public abstract boolean privileged();
+
+   @Nullable public abstract List<String> dns();
+
+   @Nullable public abstract List<String> dnsSearch();
+
+   @Nullable public abstract List<String> volumesFrom();
+
+   @Nullable public abstract List<String> capAdd();
+
+   @Nullable public abstract List<String> capDrop();
+
+   public abstract Map<String, String> restartPolicy();
+
+   Config() {
+   }
+
+   @SerializedNames(
+         {
+                 "Hostname", "Domainname", "User", "Memory", "MemorySwap", "CpuShares", "AttachStdin", "AttachStdout",
+                 "AttachStderr", "Tty", "OpenStdin", "StdinOnce", "Env", "Cmd", "Entrypoint", "Image", "Volumes",
+                 "WorkingDir", "NetworkDisabled", "ExposedPorts", "SecurityOpts", "HostConfig", "Binds", "Links",
+                 "LxcConf", "PortBindings", "PublishAllPorts", "Privileged", "Dns", "DnsSearch", "VolumesFrom",
+                 "CapAdd", "CapDrop", "RestartPolicy"
+         })
+   public static Config create(String hostname, String domainname, String user, int memory, int memorySwap,
+         int cpuShares, boolean attachStdin, boolean attachStdout, boolean attachStderr, boolean tty,
+         boolean openStdin, boolean stdinOnce, List<String> env, List<String> cmd, List<String> entrypoint,
+         String image, Map<String, ?> volumes, String workingDir, boolean networkDisabled,
+         Map<String, ?> exposedPorts, List<String> securityOpts, HostConfig hostConfig, List<String> binds,
+         List<String> links, List<Map<String, String>> lxcConf, Map<String, List<Map<String, String>>> portBindings,
+         boolean publishAllPorts, boolean privileged, List<String> dns, List<String> dnsSearch, List<String> volumesFrom,
+         List<String> capAdd, List<String> capDrop, Map<String, String> restartPolicy) {
+      return new AutoValue_Config(hostname, domainname, user, memory, memorySwap, cpuShares, attachStdin,
+              attachStdout, attachStderr, tty, openStdin, stdinOnce, copyWithNullOf(env), copyWithNullOf(cmd),
+              copyWithNullOf(entrypoint), image, copyWithNullOf(volumes), workingDir, networkDisabled,
+              copyOf(exposedPorts), copyOf(securityOpts), hostConfig,
+              copyWithNullOf(binds), copyWithNullOf(links), copyOf(lxcConf), copyOf(portBindings), publishAllPorts, privileged,
+              copyWithNullOf(dns), copyWithNullOf(dnsSearch), copyWithNullOf(volumesFrom), copyWithNullOf(capAdd), copyWithNullOf(capDrop), copyOf(restartPolicy));
+   }
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public Builder toBuilder() {
+      return builder().fromConfig(this);
+   }
+
+   public static final class Builder {
+      private String hostname;
+      private String domainname;
+      private String user;
+      private int memory;
+      private int memorySwap;
+      private int cpuShares;
+      private boolean attachStdin;
+      private boolean attachStdout;
+      private boolean attachStderr;
+      private boolean tty;
+      private boolean openStdin;
+      private boolean stdinOnce;
+      private List<String> env;
+      private List<String> cmd;
+      private List<String> entrypoint;
+      private String image;
+      private Map<String, ?> volumes;
+      private String workingDir;
+      private boolean networkDisabled;
+      private Map<String, ?> exposedPorts = Maps.newHashMap();
+      private List<String> securityOpts = Lists.newArrayList();
+      private HostConfig hostConfig;
+      private List<String> binds;
+      private List<String> links;
+      private List<Map<String, String>> lxcConf = Lists.newArrayList();
+      private Map<String, List<Map<String, String>>> portBindings = Maps.newHashMap();
+      private boolean publishAllPorts;
+      private boolean privileged;
+      private List<String> dns;
+      private List<String> dnsSearch;
+      private List<String> volumesFrom;
+      private List<String> capAdd;
+      private List<String> capDrop;
+      private Map<String, String> restartPolicy = Maps.newHashMap();
+
+      public Builder hostname(String hostname) {
+         this.hostname = hostname;
+         return this;
+      }
+
+      public Builder domainname(String domainname) {
+         this.domainname = domainname;
+         return this;
+      }
+
+      public Builder user(String user) {
+         this.user = user;
+         return this;
+      }
+
+      public Builder memory(Integer memory) {
+         if (memory != null) {
+            this.memory = memory;
+         }
+         return this;
+      }
+
+      public Builder memorySwap(Integer memorySwap) {
+         if (memorySwap != null) {
+            this.memorySwap = memorySwap;
+         }
+         return this;
+      }
+
+      public Builder cpuShares(Integer cpuShares) {
+         if (cpuShares != null) {
+            this.cpuShares = cpuShares;
+         }
+         return this;
+      }
+
+      public Builder attachStdin(boolean attachStdin) {
+         this.attachStdin = attachStdin;
+         return this;
+      }
+
+      public Builder attachStdout(boolean attachStdout) {
+         this.attachStdout = attachStdout;
+         return this;
+      }
+
+      public Builder attachStderr(boolean attachStderr) {
+         this.attachStderr = attachStderr;
+         return this;
+      }
+
+      public Builder tty(boolean tty) {
+         this.tty = tty;
+         return this;
+      }
+
+      public Builder openStdin(boolean openStdin) {
+         this.openStdin = openStdin;
+         return this;
+      }
+
+      public Builder stdinOnce(boolean stdinOnce) {
+         this.stdinOnce = stdinOnce;
+         return this;
+      }
+
+      public Builder env(List<String> env) {
+         this.env = env;
+         return this;
+      }
+
+      public Builder cmd(List<String> cmd) {
+         this.cmd = cmd;
+         return this;
+      }
+
+      public Builder entrypoint(List<String> entrypoint) {
+         this.entrypoint = entrypoint;
+         return this;
+      }
+
+      public Builder image(String image) {
+         this.image = checkNotNull(image, "image");
+         return this;
+      }
+
+      public Builder volumes(Map<String, ?> volumes) {
+         this.volumes = volumes;
+         return this;
+      }
+
+      public Builder workingDir(String workingDir) {
+         this.workingDir = workingDir;
+         return this;
+      }
+
+      public Builder networkDisabled(boolean networkDisabled) {
+         this.networkDisabled = networkDisabled;
+         return this;
+      }
+
+      public Builder exposedPorts(Map<String, ?> exposedPorts) {
+         this.exposedPorts = exposedPorts;
+         return this;
+      }
+
+      public Builder securityOpts(List<String> securityOpts) {
+         this.securityOpts = securityOpts;
+         return this;
+      }
+
+      public Builder hostConfig(HostConfig hostConfig) {
+         this.hostConfig = hostConfig;
+         return this;
+      }
+
+      public Builder binds(List<String> binds) {
+         this.binds = binds;
+         return this;
+      }
+
+      public Builder links(List<String> links) {
+         this.links = links;
+         return this;
+      }
+
+      public Builder lxcConf(List<Map<String, String>> lxcConf) {
+         this.lxcConf = lxcConf;
+         return this;
+      }
+
+      public Builder portBindings(Map<String, List<Map<String, String>>> portBindings) {
+         this.portBindings = portBindings;
+         return this;
+      }
+
+      public Builder publishAllPorts(boolean publishAllPorts) {
+         this.publishAllPorts = publishAllPorts;
+         return this;
+      }
+
+      public Builder privileged(boolean privileged) {
+         this.privileged = privileged;
+         return this;
+      }
+
+      public Builder dns(List<String>  dns) {
+         this.dns = dns;
+         return this;
+      }
+
+      public Builder dnsSearch(List<String> dnsSearch) {
+         this.dnsSearch = dnsSearch;
+         return this;
+      }
+
+      public Builder volumesFrom(List<String> volumesFrom) {
+         this.volumesFrom = volumesFrom;
+         return this;
+      }
+
+      public Builder capAdd(List<String> capAdd) {
+         this.capAdd = capAdd;
+         return this;
+      }
+
+      public Builder capDrop(List<String> capDrop) {
+         this.capDrop = capDrop;
+         return this;
+      }
+
+      public Builder restartPolicy(Map<String, String> restartPolicy) {
+         this.restartPolicy = restartPolicy;
+         return this;
+      }
+
+      public Config build() {
+         return Config.create(hostname, domainname, user, memory, memorySwap, cpuShares, attachStdin, attachStdout,
+                 attachStderr, tty, openStdin, stdinOnce, env, cmd, entrypoint, image, volumes, workingDir,
+                 networkDisabled, exposedPorts, securityOpts, hostConfig, binds, links, lxcConf, portBindings,
+                 publishAllPorts, privileged, dns, dnsSearch, volumesFrom, capAdd, capDrop, restartPolicy);
+      }
+
+      public Builder fromConfig(Config in) {
+         return hostname(in.hostname()).domainname(in.domainname()).user(in.user()).memory(in.memory())
+                 .memorySwap(in.memorySwap()).cpuShares(in.cpuShares()).attachStdin(in.attachStdin())
+                 .attachStdout(in.attachStdout()).attachStderr(in.attachStderr()).tty(in.tty())
+                 .openStdin(in.openStdin()).stdinOnce(in.stdinOnce()).env(in.env()).cmd(in.cmd())
+                 .entrypoint(in.entrypoint()).image(in.image()).volumes(in.volumes()).workingDir(in.workingDir())
+                 .networkDisabled(in.networkDisabled()).exposedPorts(in.exposedPorts()).securityOpts(in.securityOpts())
+                 .hostConfig(in.hostConfig()).binds(in.binds()).links(in.links()).lxcConf(in.lxcConf())
+                 .portBindings(in.portBindings()).publishAllPorts(in.publishAllPorts()).privileged(in.privileged())
+                 .dns(in.dns()).dnsSearch(in.dnsSearch()).volumesFrom(in.volumesFrom()).capAdd(in.capAdd())
+                 .capDrop(in.capDrop()).restartPolicy(in.restartPolicy());
+      }
+
+   }
+}

--- a/patches/src/main/java/org/jclouds/docker/domain/HostConfig.java
+++ b/patches/src/main/java/org/jclouds/docker/domain/HostConfig.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.docker.domain;
+
+import static org.jclouds.docker.internal.NullSafeCopies.copyOf;
+import static org.jclouds.docker.internal.NullSafeCopies.copyWithNullOf;
+
+import java.util.List;
+import java.util.Map;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
+@AutoValue
+public abstract class HostConfig {
+   @Nullable public abstract String containerIDFile();
+
+   @Nullable public abstract List<String> binds();
+
+   public abstract List<Map<String, String>> lxcConf();
+
+   public abstract boolean privileged();
+
+   @Nullable public abstract List<String> dns();
+
+   @Nullable public abstract List<String> dnsSearch();
+
+   public abstract Map<String, List<Map<String, String>>> portBindings();
+
+   @Nullable public abstract List<String> links();
+
+   @Nullable public abstract List<String> extraHosts();
+
+   public abstract boolean publishAllPorts();
+
+   @Nullable public abstract List<String> volumesFrom();
+
+   @Nullable public abstract String networkMode();
+
+   HostConfig() {
+   }
+
+   @SerializedNames({ "ContainerIDFile", "Binds", "LxcConf", "Privileged", "Dns", "DnsSearch", "PortBindings",
+         "Links", "ExtraHosts", "PublishAllPorts", "VolumesFrom", "NetworkMode" })
+   public static HostConfig create(String containerIDFile, List<String> binds, List<Map<String, String>> lxcConf,
+         boolean privileged, List<String> dns, List<String> dnsSearch, Map<String, List<Map<String, String>>> portBindings,
+         List<String> links, List<String> extraHosts, boolean publishAllPorts, List<String> volumesFrom, String networkMode) {
+      return new AutoValue_HostConfig(containerIDFile, copyWithNullOf(binds), copyOf(lxcConf), privileged, copyWithNullOf(dns), copyWithNullOf(dnsSearch),
+            copyOf(portBindings), copyWithNullOf(links), copyWithNullOf(extraHosts), publishAllPorts, copyWithNullOf(volumesFrom), networkMode);
+   }
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public Builder toBuilder() {
+      return builder().fromHostConfig(this);
+   }
+
+   public static final class Builder {
+
+      private String containerIDFile;
+      private List<String> binds;
+      private List<Map<String, String>> lxcConf = Lists.newArrayList();
+      private boolean privileged;
+      private List<String> dns;
+      private List<String> dnsSearch;
+      private Map<String, List<Map<String, String>>> portBindings = Maps.newLinkedHashMap();
+      private List<String> links;
+      private List<String> extraHosts;
+      private boolean publishAllPorts;
+      private List<String> volumesFrom;
+      private String networkMode;
+
+      public Builder containerIDFile(String containerIDFile) {
+         this.containerIDFile = containerIDFile;
+         return this;
+      }
+
+      public Builder binds(List<String> binds) {
+         this.binds = binds;
+         return this;
+      }
+
+      public Builder lxcConf(List<Map<String, String>> lxcConf) {
+         this.lxcConf = lxcConf;
+         return this;
+      }
+
+      public Builder privileged(boolean privileged) {
+         this.privileged = privileged;
+         return this;
+      }
+
+      public Builder dns(List<String> dns) {
+         this.dns = dns;
+         return this;
+      }
+
+      public Builder dnsSearch(List<String> dnsSearch) {
+         this.dnsSearch = dnsSearch;
+         return this;
+      }
+
+      public Builder links(List<String> links) {
+         this.links = links;
+         return this;
+      }
+
+      public Builder extraHosts(List<String> extraHosts) {
+         this.extraHosts = extraHosts;
+         return this;
+      }
+
+      public Builder portBindings(Map<String, List<Map<String, String>>> portBindings) {
+         this.portBindings = portBindings;
+         return this;
+      }
+
+      public Builder publishAllPorts(boolean publishAllPorts) {
+         this.publishAllPorts = publishAllPorts;
+         return this;
+      }
+
+      public Builder volumesFrom(List<String> volumesFrom) {
+         this.volumesFrom = volumesFrom;
+         return this;
+      }
+
+      public Builder networkMode(String networkMode) {
+         this.networkMode = networkMode;
+         return this;
+      }
+
+      public HostConfig build() {
+         return HostConfig.create(containerIDFile, binds, lxcConf, privileged, dns, dnsSearch, portBindings, links,
+               extraHosts, publishAllPorts, volumesFrom, networkMode);
+      }
+
+      public Builder fromHostConfig(HostConfig in) {
+         return this.containerIDFile(in.containerIDFile()).binds(in.binds()).lxcConf(in.lxcConf())
+               .privileged(in.privileged()).dns(in.dns()).dnsSearch(in.dnsSearch()).links(in.links())
+               .extraHosts(in.extraHosts()).portBindings(in.portBindings()).publishAllPorts(in.publishAllPorts())
+               .volumesFrom(in.volumesFrom()).networkMode(in.networkMode());
+      }
+   }
+}

--- a/patches/src/main/java/org/jclouds/docker/internal/NullSafeCopies.java
+++ b/patches/src/main/java/org/jclouds/docker/internal/NullSafeCopies.java
@@ -34,6 +34,14 @@ public class NullSafeCopies {
       return list != null ? ImmutableList.copyOf(list) : ImmutableList.<E> of();
    }
 
+   public static <E> List<E> copyOf(@Nullable Iterable<E> list) {
+      return list != null ? ImmutableList.copyOf(list) : ImmutableList.<E> of();
+   }
+
+   public static <E> List<E> copyOf(@Nullable E[] array) {
+      return array != null ? ImmutableList.copyOf(array) : ImmutableList.<E> of();
+   }
+
    /**
     * Copies given List with keeping null value if provided.
     *

--- a/patches/src/main/java/org/jclouds/docker/internal/NullSafeCopies.java
+++ b/patches/src/main/java/org/jclouds/docker/internal/NullSafeCopies.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.docker.internal;
+
+import java.util.List;
+import java.util.Map;
+
+import org.jclouds.javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public class NullSafeCopies {
+
+   public static <K, V> Map<K, V> copyOf(@Nullable Map<K, V> map) {
+      return map != null ? ImmutableMap.copyOf(map) : ImmutableMap.<K, V> of();
+   }
+
+   public static <E> List<E> copyOf(@Nullable List<E> list) {
+      return list != null ? ImmutableList.copyOf(list) : ImmutableList.<E> of();
+   }
+
+   /**
+    * Copies given List with keeping null value if provided.
+    *
+    * @param list
+    *           instance to copy (maybe <code>null</code>)
+    * @return if the parameter is not-<code>null</code> then immutable copy;
+    *         <code>null</code> otherwise
+    */
+   public static <E> List<E> copyWithNullOf(@Nullable List<E> list) {
+      return list != null ? ImmutableList.copyOf(list) : null;
+   }
+
+   /**
+    * Copies given Map with keeping null value if provided.
+    *
+    * @param map
+    *           instance to copy (maybe <code>null</code>)
+    * @return if the parameter is not-<code>null</code> then immutable copy;
+    *         <code>null</code> otherwise
+    */
+   public static <K, V> Map<K, V> copyWithNullOf(@Nullable Map<K, V> map) {
+      return map != null ? ImmutableMap.copyOf(map) : null;
+   }
+
+   /**
+    * Copies given {@link Iterable} into immutable {@link List} with keeping null value if provided.
+    *
+    * @param iterable
+    *           instance to copy (maybe <code>null</code>)
+    * @return if the parameter is not-<code>null</code> then immutable copy;
+    *         <code>null</code> otherwise
+    */
+   public static <E> List<E> copyWithNullOf(@Nullable Iterable<E> iterable) {
+      return iterable != null ? ImmutableList.copyOf(iterable) : null;
+   }
+
+   /**
+    * Copies given array into immutable {@link List} with keeping null value if provided.
+    *
+    * @param array
+    *           instance to copy (maybe <code>null</code>)
+    * @return if the parameter is not-<code>null</code> then immutable copy;
+    *         <code>null</code> otherwise
+    */
+   public static <E> List<E> copyWithNullOf(@Nullable E[] array) {
+      return array != null ? ImmutableList.copyOf(array) : null;
+   }
+
+   private NullSafeCopies() {
+   }
+}


### PR DESCRIPTION
This requires #272 to be merged.

If the `docker.host.securityGroup` is omitted then attempt to pull the securityGroup string from the location when its defined unambiguously in the location, ie a String.

Currently does not attempt to pull the securityGroup from the location when an ArrayList or Iterator, multiple securityGroup support isn't currently implemented in Clocker (should it?).