### PR TITLE
Fix behaviour when stopping containers

### DIFF
--- a/docker/src/main/java/clocker/docker/entity/DockerHostImpl.java
+++ b/docker/src/main/java/clocker/docker/entity/DockerHostImpl.java
@@ -408,7 +408,7 @@ public class DockerHostImpl extends MachineEntityImpl implements DockerHost {
         // FIXME Set DOCKER_OPTS values in command-line for when running on localhost
         String stdout = execCommandTimeout(BashCommands.sudo(String.format("docker %s", command)), timeout);
         LOG.debug("Successfully executed Docker {}: {}", Strings.getFirstWord(command), Strings.getFirstLine(stdout));
-        return stdout;
+        return Strings.trim(stdout);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Ensures `DockerContainerImpl#stop()` is called and that `docker rm` gets run on the container.