### PR TITLE
Docker libnetwork support

### DIFF
--- a/clocker.bom
+++ b/clocker.bom
@@ -278,6 +278,10 @@ brooklyn.catalog:
       type: org.apache.brooklyn.entity.proxy.haproxy.HAProxyController
       brooklyn.config:
         docker.image.name: haproxy
+        docker.useSsh: false
+        docker.image.commands:
+        - "/bin/bash"
+        docker.container.interactive: true
         docker.container.openPorts.configKeys:
         - $brooklyn:sensor("org.apache.brooklyn.entity.proxy.AbstractController", "proxy.http.port")
         - $brooklyn:sensor("org.apache.brooklyn.entity.proxy.AbstractController", "proxy.https.port")

--- a/clocker.bom
+++ b/clocker.bom
@@ -162,7 +162,7 @@ brooklyn.catalog:
     item:
       type: clocker.mesos.entity.framework.marathon.MarathonFramework
 
-  - id: docker-single
+  - id: docker-cloud-single
     name: "Clocker"
     description: |
       Single Docker host without networking

--- a/clocker.bom
+++ b/clocker.bom
@@ -77,7 +77,7 @@ brooklyn.catalog:
     item:
       type: clocker.docker.networking.entity.sdn.calico.CalicoNetwork
       brooklyn.config:
-        calico.version: 0.4.9
+        calico.version: 0.19.0
         sdn.agent.spec:
           $brooklyn:entitySpec:
             type: calico-node
@@ -109,7 +109,7 @@ brooklyn.catalog:
     item:
       type: org.apache.brooklyn.entity.nosql.etcd.EtcdCluster
       brooklyn.config:
-        etcd.version: 2.0.11
+        etcd.version: 2.3.1
         etcd.node.spec:
           $brooklyn:entitySpec:
             type: etcd-node

--- a/clocker.bom
+++ b/clocker.bom
@@ -129,6 +129,20 @@ brooklyn.catalog:
     item:
       type: clocker.docker.networking.entity.sdn.weave.WeaveRouter
 
+  - id: overlay-network
+    name: "Docker Overlay Network"
+    item:
+      type: clocker.docker.networking.entity.sdn.overlay.OverlayNetwork
+      brooklyn.config:
+        sdn.agent.spec:
+          $brooklyn:entitySpec:
+            type: overlay-plugin
+
+  - id: overlay-plugin
+    name: "Docker Overlay Plugin"
+    item:
+      type: clocker.docker.networking.entity.sdn.overlay.OverlayPlugin
+
   - id: docker-registry
     name: "Docker Registry"
     services:
@@ -148,10 +162,10 @@ brooklyn.catalog:
     item:
       type: clocker.mesos.entity.framework.marathon.MarathonFramework
 
-  - id: docker-cloud
+  - id: docker-single
     name: "Clocker"
     description: |
-      Docker Cloud infrastructure
+      Single Docker host without networking
     iconUrl: classpath://docker-logo.png
     itemType: template
     item:
@@ -219,6 +233,30 @@ brooklyn.catalog:
                     type: docker-container
                     brooklyn.config:
                       docker.container.nameFormat: "weave-%2$02x"
+
+  - id: docker-cloud-overlay
+    name: "Clocker with Docker Overlay"
+    description: |
+      Docker Cloud infrastructure with Docker overlay networking
+    iconUrl: classpath://docker-logo.png
+    itemType: template
+    item:
+      services:
+      - type: docker-infrastructure
+        brooklyn.config:
+          sdn.enable: true
+          sdn.provider.spec:
+            $brooklyn:entitySpec:
+              type: overlay-network
+          docker.host.spec:
+            $brooklyn:entitySpec:
+              type: docker-host
+              brooklyn.config:
+                docker.container.spec:
+                  $brooklyn:entitySpec:
+                    type: docker-container
+                    brooklyn.config:
+                      docker.container.nameFormat: "docker-%2$02x"
 
   - id: external-mesos-cluster
     name: "External Mesos Cluster"

--- a/dist/src/main/assembly/conf/brooklyn/default.catalog.bom
+++ b/dist/src/main/assembly/conf/brooklyn/default.catalog.bom
@@ -67,7 +67,7 @@ brooklyn.catalog:
     item:
       type: clocker.docker.networking.entity.sdn.calico.CalicoNetwork
       brooklyn.config:
-        calico.version: 0.4.9
+        calico.version: 0.19.0
         sdn.agent.spec:
           $brooklyn:entitySpec:
             type: calico-node
@@ -99,7 +99,7 @@ brooklyn.catalog:
     item:
       type: org.apache.brooklyn.entity.nosql.etcd.EtcdCluster
       brooklyn.config:
-        etcd.version: 2.0.11
+        etcd.version: 2.3.1
         etcd.node.spec:
           $brooklyn:entitySpec:
             type: etcd-node

--- a/dist/src/main/assembly/conf/brooklyn/default.catalog.bom
+++ b/dist/src/main/assembly/conf/brooklyn/default.catalog.bom
@@ -152,7 +152,7 @@ brooklyn.catalog:
     item:
       type: clocker.mesos.entity.framework.marathon.MarathonFramework
 
-  - id: docker-single
+  - id: docker-cloud-single
     name: "Clocker"
     description: |
       Single Docker host without networking

--- a/dist/src/main/assembly/conf/brooklyn/default.catalog.bom
+++ b/dist/src/main/assembly/conf/brooklyn/default.catalog.bom
@@ -259,7 +259,7 @@ brooklyn.catalog:
           id: riak-cluster
           name: "Riak Cluster"
           brooklyn.config:
-            install.version: 2.1.1
+            install.version: 2.1.4
             riak.networking.optimize: false
             network.list:
             - riak

--- a/dist/src/main/assembly/conf/brooklyn/default.catalog.bom
+++ b/dist/src/main/assembly/conf/brooklyn/default.catalog.bom
@@ -119,6 +119,20 @@ brooklyn.catalog:
     item:
       type: clocker.docker.networking.entity.sdn.weave.WeaveRouter
 
+  - id: overlay-network
+    name: "Docker Overlay Network"
+    item:
+      type: clocker.docker.networking.entity.sdn.overlay.OverlayNetwork
+      brooklyn.config:
+        sdn.agent.spec:
+          $brooklyn:entitySpec:
+            type: overlay-plugin
+
+  - id: overlay-plugin
+    name: "Docker Overlay Plugin"
+    item:
+      type: clocker.docker.networking.entity.sdn.overlay.OverlayPlugin
+
   - id: docker-registry
     name: "Docker Registry"
     services:
@@ -138,10 +152,10 @@ brooklyn.catalog:
     item:
       type: clocker.mesos.entity.framework.marathon.MarathonFramework
 
-  - id: docker-cloud
+  - id: docker-single
     name: "Clocker"
     description: |
-      Docker Cloud infrastructure
+      Single Docker host without networking
     iconUrl: classpath://docker-logo.png
     itemType: template
     item:
@@ -209,6 +223,30 @@ brooklyn.catalog:
                     type: docker-container
                     brooklyn.config:
                       docker.container.nameFormat: "weave-%2$02x"
+
+  - id: docker-cloud-overlay
+    name: "Clocker with Docker Overlay"
+    description: |
+      Docker Cloud infrastructure with Docker overlay networking
+    iconUrl: classpath://docker-logo.png
+    itemType: template
+    item:
+      services:
+      - type: docker-infrastructure
+        brooklyn.config:
+          sdn.enable: true
+          sdn.provider.spec:
+            $brooklyn:entitySpec:
+              type: overlay-network
+          docker.host.spec:
+            $brooklyn:entitySpec:
+              type: docker-host
+              brooklyn.config:
+                docker.container.spec:
+                  $brooklyn:entitySpec:
+                    type: docker-container
+                    brooklyn.config:
+                      docker.container.nameFormat: "docker-%2$02x"
 
   - id: external-mesos-cluster
     name: "External Mesos Cluster"

--- a/dist/src/main/assembly/conf/brooklyn/default.catalog.bom
+++ b/dist/src/main/assembly/conf/brooklyn/default.catalog.bom
@@ -268,6 +268,10 @@ brooklyn.catalog:
       type: org.apache.brooklyn.entity.proxy.haproxy.HAProxyController
       brooklyn.config:
         docker.image.name: haproxy
+        docker.useSsh: false
+        docker.image.commands:
+        - "/bin/bash"
+        docker.container.interactive: true
         docker.container.openPorts.configKeys:
         - $brooklyn:sensor("org.apache.brooklyn.entity.proxy.AbstractController", "proxy.http.port")
         - $brooklyn:sensor("org.apache.brooklyn.entity.proxy.AbstractController", "proxy.https.port")
@@ -323,7 +327,7 @@ brooklyn.catalog:
                 type: haproxy-controller
                 id: load-balancer
                 brooklyn.config:
-                  docker.image.tag: 1.5.9
+                  docker.image.tag: 1.6.4
                   network.list:
                   - webapp
           brooklyn.enrichers:

--- a/dist/src/main/assembly/files/blueprints/clocker-on-travis.yaml
+++ b/dist/src/main/assembly/files/blueprints/clocker-on-travis.yaml
@@ -3,4 +3,4 @@ name: Docker Cloud on Travis
 location: localhost
 
 services:
-  - type: docker-cloud
+  - type: docker-cloud-single

--- a/dist/src/main/assembly/files/blueprints/demo/clocker-demo-containers-vm-url.yaml
+++ b/dist/src/main/assembly/files/blueprints/demo/clocker-demo-containers-vm-url.yaml
@@ -23,7 +23,7 @@ services:
   location: jclouds:softlayer:lon02
   id: redis
   name: "Redis Store"
-  install.version: 3.0.0
+  install.version: 3.0.3
   start.timeout: 10m
 
 - type: docker:clockercentral/dnmonster:1.0
@@ -40,8 +40,8 @@ services:
   portBindings:
     80: 9090
   links:
-  - $brooklyn:component("redis")
-  - $brooklyn:component("dnmonster")
+    redis: $brooklyn:component("redis")
+    dnmonster: $brooklyn:component("dnmonster")
   brooklyn.enrichers:
   - type: org.apache.brooklyn.enricher.stock.Transformer
     brooklyn.config:

--- a/dist/src/main/assembly/files/blueprints/demo/clocker-demo-containers-vm-url.yaml
+++ b/dist/src/main/assembly/files/blueprints/demo/clocker-demo-containers-vm-url.yaml
@@ -33,7 +33,7 @@ services:
   openPorts:
   - 8080
 
-- type: docker:clockercentral/identidock:1.1
+- type: docker:clockercentral/identidock:1.9
   location: my-docker-cloud
   id: identidock
   name: "Identidock Web Application"

--- a/dist/src/main/assembly/files/blueprints/demo/clocker-demo-containers-vm.yaml
+++ b/dist/src/main/assembly/files/blueprints/demo/clocker-demo-containers-vm.yaml
@@ -30,7 +30,7 @@ services:
   openPorts:
   - 8080
 
-- type: docker:clockercentral/identidock:1.1
+- type: docker:clockercentral/identidock:1.9
   location: openstack-docker-cloud
   id: identidock
   portBindings:

--- a/dist/src/main/assembly/files/blueprints/demo/clocker-demo-containers-vm.yaml
+++ b/dist/src/main/assembly/files/blueprints/demo/clocker-demo-containers-vm.yaml
@@ -21,7 +21,7 @@ services:
 - type: org.apache.brooklyn.entity.nosql.redis.RedisStore
   location: jclouds:softlayer:lon02
   id: redis
-  install.version: 3.0.0
+  install.version: 3.0.3
   start.timeout: 10m
 
 - type: docker:clockercentral/dnmonster:1.0
@@ -36,7 +36,7 @@ services:
   portBindings:
     80: 9090
   links:
-  - $brooklyn:component("redis")
-  - $brooklyn:component("dnmonster")
+    redis: $brooklyn:component("redis")
+    dnminster: $brooklyn:component("dnmonster")
 
 # vim:ts=2:sw=2:ft=yaml:

--- a/dist/src/main/assembly/files/blueprints/demo/clocker-demo-containers.yaml
+++ b/dist/src/main/assembly/files/blueprints/demo/clocker-demo-containers.yaml
@@ -30,7 +30,7 @@ services:
   openPorts:
   - 8080
 
-- type: docker:clockercentral/identidock:1.1
+- type: docker:clockercentral/identidock:1.9
   id: identidock
   portBindings:
     80: 9090

--- a/dist/src/main/assembly/files/blueprints/demo/clocker-demo-containers.yaml
+++ b/dist/src/main/assembly/files/blueprints/demo/clocker-demo-containers.yaml
@@ -35,7 +35,7 @@ services:
   portBindings:
     80: 9090
   links:
-  - $brooklyn:component("redis")
-  - $brooklyn:component("dnmonster")
+    redis: $brooklyn:component("redis")
+    dnmonster: $brooklyn:component("dnmonster")
 
 # vim:ts=2:sw=2:ft=yaml:

--- a/dist/src/main/assembly/files/blueprints/demo/dockercon-clocker-demo.yaml
+++ b/dist/src/main/assembly/files/blueprints/demo/dockercon-clocker-demo.yaml
@@ -24,7 +24,7 @@ services:
   location: my-openstack-cloud
   id: redis
   name: "Redis Store"
-  install.version: 3.0.0
+  install.version: 3.0.3
   start.timeout: 10m
 
 - type: docker:clockercentral/dnmonster:1.0
@@ -43,8 +43,8 @@ services:
   openPorts:
   - 9091
   links:
-  - $brooklyn:component("redis")
-  - $brooklyn:component("dnmonster")
+    redis: $brooklyn:component("redis")
+    dnmonster: $brooklyn:component("dnmonster")
   brooklyn.enrichers:
   - type: org.apache.brooklyn.enricher.stock.Transformer
     brooklyn.config:

--- a/dist/src/main/assembly/files/blueprints/demo/dockercon-clocker-demo.yaml
+++ b/dist/src/main/assembly/files/blueprints/demo/dockercon-clocker-demo.yaml
@@ -34,7 +34,7 @@ services:
   openPorts:
   - 8080
 
-- type: docker:clockercentral/identidock:1.1
+- type: docker:clockercentral/identidock:1.9
   location: my-docker-cloud
   id: identidock
   name: "Identidock Web Application"

--- a/dist/src/main/assembly/files/blueprints/docker-host.yaml
+++ b/dist/src/main/assembly/files/blueprints/docker-host.yaml
@@ -18,7 +18,7 @@ origin: https://github.com/brooklyncentral/clocker/
 location: jclouds:softlayer:ams01
 
 services:
-- type: docker-cloud
+- type: docker-cloud-single
   brooklyn.config:
     entity.dynamicLocation.name: "my-docker-cloud"
     docker.version: 1.10.3 # DOCKER_VERSION

--- a/dist/src/test/resources/quality_assurance/combined_test.yaml
+++ b/dist/src/test/resources/quality_assurance/combined_test.yaml
@@ -9,7 +9,7 @@ brooklyn.catalog:
         brooklyn.config:
           appToTest:
             $brooklyn:entitySpec:
-              - type: "docker-cloud:1.1.0-SNAPSHOT" # CLOCKER_VERSION
+              - type: "docker-cloud-single:1.1.0-SNAPSHOT" # CLOCKER_VERSION
                 id: infrastructure1
                 brooklyn.config:
                   docker.host.cluster.initial.size: 2

--- a/dist/src/test/resources/quality_assurance/test_app.yaml
+++ b/dist/src/test/resources/quality_assurance/test_app.yaml
@@ -6,7 +6,7 @@ brooklyn.catalog:
   license: Apache-2.0
   item:
     services:
-      - type: "docker-cloud:1.1.0-SNAPSHOT" # CLOCKER_VERSION
+      - type: "docker-cloud-single:1.1.0-SNAPSHOT" # CLOCKER_VERSION
         id: infrastructure1
         brooklyn.config:
           entity.dynamicLocation.name: my-docker-cloud

--- a/docker/src/main/java/clocker/docker/entity/DockerHost.java
+++ b/docker/src/main/java/clocker/docker/entity/DockerHost.java
@@ -86,7 +86,13 @@ public interface DockerHost extends MachineEntity, HasShortName, LocationOwner<D
 
     @SetFromFlag("dockerSslPort")
     PortAttributeSensorAndConfigKey DOCKER_SSL_PORT = ConfigKeys.newPortSensorAndConfigKey("docker.ssl.port",
-            "Docker port", PortRanges.fromInteger(2376));
+            "Docker SSL port", PortRanges.fromInteger(2376));
+
+    ConfigKey<Integer> DOCKER_CONTROL_PLANE_PORT = ConfigKeys.newIntegerConfigKey("docker.control.port",
+            "Docker control plane port (TCP and UDP)", 7946);
+
+    ConfigKey<Integer> DOCKER_DATA_PLANE_PORT = ConfigKeys.newIntegerConfigKey("docker.data.port",
+            "Docker data plane port (UDP)", 4789);
 
     @SetFromFlag("openIptables")
     ConfigKey<Boolean> OPEN_IPTABLES = ConfigKeys.newConfigKeyWithPrefix("docker.host.", SoftwareProcess.OPEN_IPTABLES);

--- a/docker/src/main/java/clocker/docker/entity/DockerHost.java
+++ b/docker/src/main/java/clocker/docker/entity/DockerHost.java
@@ -47,6 +47,7 @@ import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.PortAttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.entity.machine.MachineEntity;
+import org.apache.brooklyn.entity.nosql.etcd.EtcdNode;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.location.jclouds.JcloudsLocation;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
@@ -149,6 +150,8 @@ public interface DockerHost extends MachineEntity, HasShortName, LocationOwner<D
             "docker.addLocalhostPermission",
             "When true, will add the localhost IP address to the docker host as an acceptable ingress address. This is useful when running Clocker in the same network as the hosts will be run in (e.g. same AWS availibility zone).",
             false);
+
+    AttributeSensor<EtcdNode> ETCD_NODE = Sensors.newSensor(EtcdNode.class, "etcd.node", "The EtcdNode attached to this DockerHost");
 
     String getLoginPassword();
 

--- a/docker/src/main/java/clocker/docker/entity/DockerHostImpl.java
+++ b/docker/src/main/java/clocker/docker/entity/DockerHostImpl.java
@@ -16,9 +16,7 @@
 package clocker.docker.entity;
 
 import java.io.File;
-import java.net.InetAddress;
 import java.net.URI;
-import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -56,7 +54,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 
 import org.jclouds.compute.domain.OsFamily;
 import org.jclouds.compute.domain.TemplateBuilder;
@@ -117,6 +114,7 @@ import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.QuorumCheck.QuorumChecks;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.internal.ssh.SshTool;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.core.task.system.ProcessTaskStub.ScriptReturnType;

--- a/docker/src/main/java/clocker/docker/entity/DockerHostImpl.java
+++ b/docker/src/main/java/clocker/docker/entity/DockerHostImpl.java
@@ -319,6 +319,12 @@ public class DockerHostImpl extends MachineEntityImpl implements DockerHost {
                 flags.put(JcloudsLocationConfig.TEMPLATE_BUILDER.getName(), template);
 
                 customizers.add(SoftLayerSameVlanLocationCustomizer.forScope(getApplicationId()));
+
+                config().set(DockerInfrastructure.USE_JCLOUDS_HOSTNAME_CUSTOMIZER, true);
+            }
+
+            // Set hostname customizer if configured
+            if (config().get(DockerInfrastructure.USE_JCLOUDS_HOSTNAME_CUSTOMIZER)) {
                 customizers.add(JcloudsHostnameCustomizer.instanceOf());
             }
 

--- a/docker/src/main/java/clocker/docker/entity/DockerHostSshDriver.java
+++ b/docker/src/main/java/clocker/docker/entity/DockerHostSshDriver.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 
 import clocker.docker.entity.util.DockerUtils;
-import clocker.docker.networking.entity.sdn.calico.CalicoNode;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
@@ -46,8 +45,6 @@ import com.google.common.net.HostAndPort;
 import org.jclouds.compute.ComputeService;
 import org.jclouds.softlayer.reference.SoftLayerConstants;
 
-import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.location.MachineProvisioningLocation;
 import org.apache.brooklyn.api.location.OsDetails;
 import org.apache.brooklyn.api.mgmt.Task;

--- a/docker/src/main/java/clocker/docker/entity/DockerHostSshDriver.java
+++ b/docker/src/main/java/clocker/docker/entity/DockerHostSshDriver.java
@@ -280,7 +280,7 @@ public class DockerHostSshDriver extends AbstractSoftwareProcessSshDriver implem
 
         // Setup SoftLayer hostname after reboot
         MachineProvisioningLocation<?> provisioner = getEntity().sensors().get(SoftwareProcess.PROVISIONING_LOCATION);
-        if (DockerUtils.isJcloudsLocation(provisioner, SoftLayerConstants.SOFTLAYER_PROVIDER_NAME)) {
+        if (getEntity().config().get(DockerInfrastructure.USE_JCLOUDS_HOSTNAME_CUSTOMIZER)) {
             JcloudsHostnameCustomizer.instanceOf().customize((JcloudsLocation) provisioner, (ComputeService) null, (JcloudsMachineLocation) location);
         }
 

--- a/docker/src/main/java/clocker/docker/entity/DockerHostSshDriver.java
+++ b/docker/src/main/java/clocker/docker/entity/DockerHostSshDriver.java
@@ -499,6 +499,7 @@ public class DockerHostSshDriver extends AbstractSoftwareProcessSshDriver implem
         return newScript(CHECK_RUNNING)
                 .body.append(sudo("docker version"))
                 .failOnNonZeroResultCode()
+                .uniqueSshConnection()
                 .execute() == 0;
     }
 

--- a/docker/src/main/java/clocker/docker/entity/DockerInfrastructure.java
+++ b/docker/src/main/java/clocker/docker/entity/DockerInfrastructure.java
@@ -45,6 +45,7 @@ import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.entity.group.DynamicCluster;
 import org.apache.brooklyn.entity.group.DynamicGroup;
 import org.apache.brooklyn.entity.group.DynamicMultiGroup;
+import org.apache.brooklyn.entity.nosql.etcd.EtcdCluster;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
@@ -150,6 +151,15 @@ public interface DockerInfrastructure extends StartableApplication, Resizable, L
     ConfigKey<String> DOCKER_IMAGE_REGISTRY_PASSWORD = ConfigKeys.newStringConfigKey("docker.registry.password", "Password for docker registry access");
 
     AttributeSensor<Entity> DOCKER_IMAGE_REGISTRY = DockerAttributes.DOCKER_IMAGE_REGISTRY;
+
+    @SetFromFlag("etcdVersion")
+    ConfigKey<String> ETCD_VERSION = ConfigKeys.newStringConfigKey("etcd.version", "The Etcd version number", "2.3.1");
+
+    ConfigKey<Boolean> EXTERNAL_ETCD_CLUSTER = ConfigKeys.newBooleanConfigKey("etcd.external", "Whether to use an external Etcd cluster", Boolean.FALSE);
+    ConfigKey<Integer> EXTERNAL_ETCD_INITIAL_SIZE = ConfigKeys.newIntegerConfigKey("etcd.external.initialSize", "The initial size of the external Etcd cluster");
+    AttributeSensorAndConfigKey<String, String> EXTERNAL_ETCD_URL = ConfigKeys.newStringSensorAndConfigKey("etcd.external.url", "The URL for the external Etcd cluster (if configured, no cluster will be provisioned)");
+
+    AttributeSensor<EtcdCluster> ETCD_CLUSTER = Sensors.newSensor(EtcdCluster.class, "etcd.cluster", "The EtcdCluster entity for storing state");
 
     AttributeSensor<DynamicCluster> DOCKER_HOST_CLUSTER = Sensors.newSensor(DynamicCluster.class, "docker.hosts", "Docker host cluster");
     AttributeSensor<DynamicGroup> DOCKER_CONTAINER_FABRIC = Sensors.newSensor(DynamicGroup.class, "docker.fabric", "Docker container fabric");

--- a/docker/src/main/java/clocker/docker/entity/DockerInfrastructure.java
+++ b/docker/src/main/java/clocker/docker/entity/DockerInfrastructure.java
@@ -163,7 +163,7 @@ public interface DockerInfrastructure extends StartableApplication, Resizable, L
 
     AttributeSensor<DynamicCluster> DOCKER_HOST_CLUSTER = Sensors.newSensor(DynamicCluster.class, "docker.hosts", "Docker host cluster");
     AttributeSensor<DynamicGroup> DOCKER_CONTAINER_FABRIC = Sensors.newSensor(DynamicGroup.class, "docker.fabric", "Docker container fabric");
-    AttributeSensor<DynamicMultiGroup> DOCKER_APPLICATIONS = Sensors.newSensor(DynamicMultiGroup.class, "docker.buckets", "Docker applications");
+
     AttributeSensor<Entity> SDN_PROVIDER = SdnAttributes.SDN_PROVIDER;
 
     AttributeSensor<AtomicInteger> DOCKER_HOST_COUNTER = Sensors.newSensor(AtomicInteger.class, "docker.hosts.counter", "Docker host counter");

--- a/docker/src/main/java/clocker/docker/entity/DockerInfrastructure.java
+++ b/docker/src/main/java/clocker/docker/entity/DockerInfrastructure.java
@@ -152,6 +152,8 @@ public interface DockerInfrastructure extends StartableApplication, Resizable, L
 
     AttributeSensor<Entity> DOCKER_IMAGE_REGISTRY = DockerAttributes.DOCKER_IMAGE_REGISTRY;
 
+    ConfigKey<Boolean> USE_JCLOUDS_HOSTNAME_CUSTOMIZER = ConfigKeys.newBooleanConfigKey("docker.hostname.customizer", "Fix issues with hostname in some clouds", Boolean.FALSE);
+
     @SetFromFlag("etcdVersion")
     ConfigKey<String> ETCD_VERSION = ConfigKeys.newStringConfigKey("etcd.version", "The Etcd version number", "2.3.1");
 

--- a/docker/src/main/java/clocker/docker/entity/DockerInfrastructureImpl.java
+++ b/docker/src/main/java/clocker/docker/entity/DockerInfrastructureImpl.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.annotation.Nullable;
 import javax.net.ssl.X509TrustManager;
 
 import org.slf4j.Logger;
@@ -77,11 +76,9 @@ import org.apache.brooklyn.core.location.BasicLocationRegistry;
 import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.core.location.dynamic.LocationOwner;
 import org.apache.brooklyn.enricher.stock.Enrichers;
-import org.apache.brooklyn.entity.group.BasicGroup;
 import org.apache.brooklyn.entity.group.Cluster;
 import org.apache.brooklyn.entity.group.DynamicCluster;
 import org.apache.brooklyn.entity.group.DynamicGroup;
-import org.apache.brooklyn.entity.group.DynamicMultiGroup;
 import org.apache.brooklyn.entity.machine.MachineAttributes;
 import org.apache.brooklyn.entity.nosql.etcd.EtcdCluster;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
@@ -195,19 +192,6 @@ public class DockerInfrastructureImpl extends AbstractApplication implements Doc
                 .configure(DynamicGroup.ENTITY_FILTER, Predicates.and(Predicates.instanceOf(DockerContainer.class), EntityPredicates.attributeEqualTo(DockerContainer.DOCKER_INFRASTRUCTURE, this)))
                 .displayName("All Docker Containers"));
 
-        DynamicMultiGroup buckets = addChild(EntitySpec.create(DynamicMultiGroup.class)
-                .configure(DynamicMultiGroup.ENTITY_FILTER,
-                        Predicates.and(DockerUtils.sameInfrastructure(this), Predicates.not(EntityPredicates.applicationIdEqualTo(getApplicationId()))))
-                .configure(DynamicMultiGroup.RESCAN_INTERVAL, 15L)
-                .configure(DynamicMultiGroup.BUCKET_FUNCTION, new Function<Entity, String>() {
-                    @Override
-                    public String apply(@Nullable Entity input) {
-                        return input.getApplication().getDisplayName() + ":" + input.getApplicationId();
-                    }
-                })
-                .configure(DynamicMultiGroup.BUCKET_SPEC, EntitySpec.create(BasicGroup.class))
-                .displayName("Docker Applications"));
-
         if (config().get(SDN_ENABLE) && config().get(SDN_PROVIDER_SPEC) != null) {
             EntitySpec entitySpec = EntitySpec.create(config().get(SDN_PROVIDER_SPEC));
             entitySpec.configure(DockerAttributes.DOCKER_INFRASTRUCTURE, this);
@@ -217,7 +201,6 @@ public class DockerInfrastructureImpl extends AbstractApplication implements Doc
 
         sensors().set(DOCKER_HOST_CLUSTER, hosts);
         sensors().set(DOCKER_CONTAINER_FABRIC, fabric);
-        sensors().set(DOCKER_APPLICATIONS, buckets);
 
         hosts.enrichers().add(Enrichers.builder()
                 .aggregating(DockerHost.CPU_USAGE)
@@ -496,7 +479,6 @@ public class DockerInfrastructureImpl extends AbstractApplication implements Doc
 
         RendererHints.register(DOCKER_HOST_CLUSTER, RendererHints.openWithUrl(DelegateEntity.EntityUrl.entityUrl()));
         RendererHints.register(DOCKER_CONTAINER_FABRIC, RendererHints.openWithUrl(DelegateEntity.EntityUrl.entityUrl()));
-        RendererHints.register(DOCKER_APPLICATIONS, RendererHints.openWithUrl(DelegateEntity.EntityUrl.entityUrl()));
         RendererHints.register(SDN_PROVIDER, RendererHints.openWithUrl(DelegateEntity.EntityUrl.entityUrl()));
         RendererHints.register(ETCD_CLUSTER, RendererHints.openWithUrl(DelegateEntity.EntityUrl.entityUrl()));
     }

--- a/docker/src/main/java/clocker/docker/entity/JcloudsHostnameCustomizer.java
+++ b/docker/src/main/java/clocker/docker/entity/JcloudsHostnameCustomizer.java
@@ -36,7 +36,7 @@ import org.apache.brooklyn.util.core.task.DynamicTasks;
 import org.apache.brooklyn.util.ssh.BashCommands;
 
 /**
- * Fix hostname issues on SoftLayer.
+ * Fix hostname issues.
  */
 public class JcloudsHostnameCustomizer extends BasicJcloudsLocationCustomizer {
 

--- a/docker/src/main/java/clocker/docker/entity/container/DockerContainer.java
+++ b/docker/src/main/java/clocker/docker/entity/container/DockerContainer.java
@@ -68,6 +68,9 @@ public interface DockerContainer extends BasicStartable, HasNetworkAddresses, Ha
     @SetFromFlag("privileged")
     ConfigKey<Boolean> PRIVILEGED = DockerAttributes.PRIVILEGED;
 
+    @SetFromFlag("interactive")
+    ConfigKey<Boolean> INTERACTIVE = DockerAttributes.INTERACTIVE;
+
     @SetFromFlag("managed")
     ConfigKey<Boolean> MANAGED = DockerAttributes.MANAGED;
 

--- a/docker/src/main/java/clocker/docker/entity/container/DockerContainerImpl.java
+++ b/docker/src/main/java/clocker/docker/entity/container/DockerContainerImpl.java
@@ -47,7 +47,6 @@ import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.Ints;
 
@@ -69,7 +68,6 @@ import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
-import org.apache.brooklyn.core.entity.trait.StartableMethods;
 import org.apache.brooklyn.core.feed.ConfigToAttributes;
 import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
@@ -540,6 +538,29 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
         }
 
         try {
+            // If SDN is enabled, create networks
+            if (config().get(SdnAttributes.SDN_ENABLE)) {
+                // Determine list of networks for the entity
+                List<String> networks = MutableList.of();
+                Collection<String> extra = entity.config().get(SdnAttributes.NETWORK_LIST);
+                if (entity.config().get(SdnAttributes.CREATE_APPLICATION_NETWORK)) {
+                    networks.add(entity.getApplicationId());
+                }
+                if (extra != null && extra.size() > 0) {
+                    networks.addAll(extra);
+                }
+                if (networks.isEmpty()) {
+                    throw new IllegalStateException("No networks configured for container");
+                }
+
+                // Save attached network list
+                sensors().set(SdnAttributes.INITIAL_ATTACHED_NETWORK, networks.get(0));
+                entity.sensors().set(SdnAttributes.INITIAL_ATTACHED_NETWORK, networks.get(0));
+                sensors().set(SdnAttributes.ATTACHED_NETWORKS, networks);
+                entity.sensors().set(SdnAttributes.ATTACHED_NETWORKS, networks);
+            }
+            options.networkMode(SdnAttributes.DEFAULT_NETWORK); // For port forwarding
+
             // Create a new container using jclouds Docker driver
             JcloudsSshMachineLocation container = (JcloudsSshMachineLocation) host.getJcloudsLocation().obtain(dockerFlags);
             String containerId = container.getJcloudsId();
@@ -557,26 +578,24 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
             // If SDN is enabled, attach networks
             if (config().get(SdnAttributes.SDN_ENABLE)) {
                 SdnAgent agent = Entities.attributeSupplierWhenReady(dockerHost, SdnAgent.SDN_AGENT).get();
-
-                // Save attached network list
-                List<String> networks = Lists.newArrayList(entity.getApplicationId());
-                Collection<String> extra = entity.config().get(SdnAttributes.NETWORK_LIST);
-                if (extra != null) networks.addAll(extra);
-                sensors().set(SdnAttributes.ATTACHED_NETWORKS, networks);
-                entity.sensors().set(SdnAttributes.ATTACHED_NETWORKS, networks);
-
-                // Save container addresses
+                String initialNetwork = sensors().get(SdnAttributes.INITIAL_ATTACHED_NETWORK);
+                List<String> networks = sensors().get(SdnAttributes.ATTACHED_NETWORKS);
                 Set<String> addresses = Sets.newHashSet();
+
+                // Create and attach networks
                 for (String networkId : networks) {
+                    agent.createNetwork(networkId);
                     InetAddress address = agent.attachNetwork(containerId, networkId);
                     addresses.add(address.getHostAddress());
-                    if (networkId.equals(entity.getApplicationId())) {
+                    if (networkId.equals(initialNetwork)) {
                         sensors().set(Attributes.SUBNET_ADDRESS, address.getHostAddress());
                         sensors().set(Attributes.SUBNET_HOSTNAME, address.getHostName());
                         entity.sensors().set(Attributes.SUBNET_ADDRESS, address.getHostAddress());
                         entity.sensors().set(Attributes.SUBNET_HOSTNAME, address.getHostName());
                     }
                 }
+
+                // Save container addresses
                 sensors().set(CONTAINER_ADDRESSES, addresses);
                 entity.sensors().set(CONTAINER_ADDRESSES, addresses);
             }

--- a/docker/src/main/java/clocker/docker/entity/container/DockerContainerImpl.java
+++ b/docker/src/main/java/clocker/docker/entity/container/DockerContainerImpl.java
@@ -439,6 +439,9 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
         Boolean privileged = entity.config().get(DockerContainer.PRIVILEGED);
         options.privileged(privileged);
 
+        Boolean openStdin = entity.config().get(DockerContainer.INTERACTIVE);
+        options.openStdin(openStdin);
+
         // Log for debugging without password
         LOG.debug("Docker options for {}: {}", entity, options);
 

--- a/docker/src/main/java/clocker/docker/entity/container/DockerContainerImpl.java
+++ b/docker/src/main/java/clocker/docker/entity/container/DockerContainerImpl.java
@@ -435,6 +435,10 @@ public class DockerContainerImpl extends BasicStartableImpl implements DockerCon
             entity.sensors().set(DockerAttributes.DOCKER_IMAGE_COMMANDS, commands);
         }
 
+        // Privileged container
+        Boolean privileged = entity.config().get(DockerContainer.PRIVILEGED);
+        options.privileged(privileged);
+
         // Log for debugging without password
         LOG.debug("Docker options for {}: {}", entity, options);
 

--- a/docker/src/main/java/clocker/docker/entity/util/DockerAttributes.java
+++ b/docker/src/main/java/clocker/docker/entity/util/DockerAttributes.java
@@ -112,6 +112,9 @@ public class DockerAttributes {
     public static final ConfigKey<Boolean> PRIVILEGED = ConfigKeys.newBooleanConfigKey(
             "docker.container.privileged", "Set to true if the container is to be privileged", Boolean.TRUE);
 
+    public static final ConfigKey<Boolean> INTERACTIVE = ConfigKeys.newBooleanConfigKey(
+            "docker.container.interactive", "Set to true if STDIN is to be kept open for an interactive container", Boolean.FALSE);
+
     public static final ConfigKey<Boolean> MANAGED = ConfigKeys.newBooleanConfigKey(
             "docker.container.managed", "Set to false if the container is not managed by Brooklyn and Clocker", Boolean.TRUE);
 

--- a/docker/src/main/java/clocker/docker/entity/util/DockerUtils.java
+++ b/docker/src/main/java/clocker/docker/entity/util/DockerUtils.java
@@ -59,7 +59,6 @@ import org.apache.brooklyn.core.config.render.RendererHints.NamedActionWithUrl;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityAndAttribute;
-import org.apache.brooklyn.core.location.Machines;
 import org.apache.brooklyn.core.location.PortRanges;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.objs.BrooklynObjectInternal.ConfigurationSupportInternal;
@@ -97,6 +96,8 @@ public class DockerUtils {
     /*
      * Configuration and constants.
      */
+
+    public static final String BRIDGE_NETWORK = "bridge";
 
     public static final String DOCKERFILE = "Dockerfile";
     public static final String ENTRYPOINT = "entrypoint.sh";

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/DockerNetworkAgentDriver.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/DockerNetworkAgentDriver.java
@@ -13,10 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package clocker.docker.networking.entity.sdn.calico;
+package clocker.docker.networking.entity.sdn;
 
-import clocker.docker.networking.entity.sdn.DockerNetworkAgentDriver;
+import java.util.List;
 
-public interface CalicoNodeDriver extends DockerNetworkAgentDriver {
+public interface DockerNetworkAgentDriver extends SdnAgentDriver {
+
+    String getDockerNetworkDriver();
+
+    List<String> getDockerNetworkCreateOpts();
 
 }

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/DockerNetworkAgentSshDriver.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/DockerNetworkAgentSshDriver.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.api.client.util.Joiner;
+import com.google.common.base.Joiner;
 import com.google.common.collect.Iterables;
 
 import org.apache.brooklyn.api.entity.EntityLocal;
@@ -32,11 +32,11 @@ import org.apache.brooklyn.util.net.Cidr;
 import org.apache.brooklyn.util.net.Networking;
 import org.apache.brooklyn.util.text.StringFunctions;
 
-public abstract class DockerNetworkAgentrSshDriver extends AbstractSoftwareProcessSshDriver implements DockerNetworkAgentDriver {
+public abstract class DockerNetworkAgentSshDriver extends AbstractSoftwareProcessSshDriver implements DockerNetworkAgentDriver {
 
     private static final Logger LOG = LoggerFactory.getLogger(SdnAgent.class);
 
-    public DockerNetworkAgentrSshDriver(EntityLocal entity, SshMachineLocation machine) {
+    public DockerNetworkAgentSshDriver(EntityLocal entity, SshMachineLocation machine) {
         super(entity, machine);
     }
 

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/DockerNetworkAgentrSshDriver.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/DockerNetworkAgentrSshDriver.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014-2016 by Cloudsoft Corporation Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package clocker.docker.networking.entity.sdn;
+
+import java.net.InetAddress;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import clocker.docker.networking.entity.sdn.util.SdnAttributes;
+
+import com.google.api.client.util.Joiner;
+import com.google.common.collect.Iterables;
+
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.entity.software.base.AbstractSoftwareProcessSshDriver;
+import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.net.Cidr;
+import org.apache.brooklyn.util.net.Networking;
+import org.apache.brooklyn.util.text.StringFunctions;
+
+public abstract class DockerNetworkAgentrSshDriver extends AbstractSoftwareProcessSshDriver implements DockerNetworkAgentDriver {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SdnAgent.class);
+
+    public DockerNetworkAgentrSshDriver(EntityLocal entity, SshMachineLocation machine) {
+        super(entity, machine);
+    }
+
+    @Override
+    public List<String> getDockerNetworkCreateOpts() {
+        List<String> opts = MutableList.of();
+        return opts;
+    }
+
+    @Override
+    public void createSubnet(String subnetId, Cidr subnetCidr) {
+        Iterable<String> opts = Iterables.transform(getDockerNetworkCreateOpts(), StringFunctions.prepend("--opt "));
+        getEntity().sensors().get(SdnAgent.DOCKER_HOST).runDockerCommand(
+                String.format("network create --driver %s %s --subnet=%s %s",
+                        getDockerNetworkDriver(), Joiner.on(' ').join(opts), subnetCidr, subnetId));
+    }
+
+    @Override
+    public void deleteSubnet(String subnetId) {
+        getEntity().sensors().get(SdnAgent.DOCKER_HOST).runDockerCommand(
+                String.format("network rm --driver %s %s", getDockerNetworkDriver(), subnetId));
+    }
+
+    @Override
+    public InetAddress attachNetwork(String containerId, String subnetId) {
+        // Attach the container to the network if it is not the default
+        if (!subnetId.equals(SdnAttributes.DEFAULT_NETWORK)) {
+            getEntity().sensors().get(SdnAgent.DOCKER_HOST).runDockerCommand(
+                    String.format("network connect %s %s", subnetId, containerId));
+        }
+
+        // Look up the container address on the network
+        String ip = getEntity().sensors().get(SdnAgent.DOCKER_HOST).runDockerCommand(
+                String.format("inspect --format \"{{ .NetworkSettings.Networks.%s.IPAddress }}\" %s", subnetId, containerId));
+        InetAddress address = Networking.getInetAddressWithFixedName(ip);
+
+        // Return the containers IP address
+        getEntity().sensors().get(SdnAgent.SDN_PROVIDER).recordContainerAddress(subnetId, address);
+        getEntity().sensors().get(SdnAgent.SDN_PROVIDER).associateContainerAddress(containerId, address);
+        return address;
+    }
+
+}

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/DockerNetworkAgentrSshDriver.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/DockerNetworkAgentrSshDriver.java
@@ -21,8 +21,6 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import clocker.docker.networking.entity.sdn.util.SdnAttributes;
-
 import com.google.api.client.util.Joiner;
 import com.google.common.collect.Iterables;
 
@@ -64,11 +62,9 @@ public abstract class DockerNetworkAgentrSshDriver extends AbstractSoftwareProce
 
     @Override
     public InetAddress attachNetwork(String containerId, String subnetId) {
-        // Attach the container to the network if it is not the default
-        if (!subnetId.equals(SdnAttributes.DEFAULT_NETWORK)) {
-            getEntity().sensors().get(SdnAgent.DOCKER_HOST).runDockerCommand(
-                    String.format("network connect %s %s", subnetId, containerId));
-        }
+        // Attach the container to the network
+        getEntity().sensors().get(SdnAgent.DOCKER_HOST).runDockerCommand(
+                String.format("network connect %s %s", subnetId, containerId));
 
         // Look up the container address on the network
         String ip = getEntity().sensors().get(SdnAgent.DOCKER_HOST).runDockerCommand(

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/SdnAgent.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/SdnAgent.java
@@ -50,6 +50,20 @@ public interface SdnAgent extends SoftwareProcess {
 
     String provisionNetwork(VirtualNetwork network);
 
+    void deallocateNetwork(VirtualNetwork network);
+
+    MethodEffector<InetAddress> CREATE_NETWORK = new MethodEffector<InetAddress>(SdnAgent.class, "createNetwork");
+
+    /**
+     * Create a network.
+     *
+     * @param networkId the network ID to create
+     * @return the {@link VirtualNetwork}
+     */
+    @Effector(description="Create a network")
+    VirtualNetwork createNetwork(
+            @EffectorParam(name="networkId", description="Network ID") String networkId);
+
     MethodEffector<InetAddress> ATTACH_NETWORK = new MethodEffector<InetAddress>(SdnAgent.class, "attachNetwork");
 
     /**

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/SdnAgentDriver.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/SdnAgentDriver.java
@@ -22,7 +22,9 @@ import org.apache.brooklyn.util.net.Cidr;
 
 public interface SdnAgentDriver extends SoftwareProcessDriver {
 
-    void createSubnet(String virtualNetworkId, String subnetId, Cidr subnetCidr);
+    void createSubnet(String subnetId, Cidr subnetCidr);
+
+    void deleteSubnet(String subnetId);
 
     InetAddress attachNetwork(String containerId, String subnetId);
 

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/SdnAgentImpl.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/SdnAgentImpl.java
@@ -85,10 +85,14 @@ public abstract class SdnAgentImpl extends SoftwareProcessImpl implements SdnAge
     }
 
     @Override
-    public InetAddress attachNetwork(String containerId, final String networkId) {
+    public VirtualNetwork createNetwork(String networkId) {
         final SdnProvider provider = sensors().get(SDN_PROVIDER);
         VirtualNetwork network = SdnUtils.createNetwork(provider, networkId);
+        return network;
+    }
 
+    @Override
+    public InetAddress attachNetwork(String containerId, final String networkId) {
         InetAddress address = getDriver().attachNetwork(containerId, networkId);
         LOG.info("Attached container ID {} to {}: {}", new Object[] { containerId, networkId,  address.getHostAddress() });
 
@@ -103,9 +107,17 @@ public abstract class SdnAgentImpl extends SoftwareProcessImpl implements SdnAge
         Cidr subnetCidr = SdnUtils.provisionNetwork(provider, network);
 
         // Create the network using the SDN driver
-        getDriver().createSubnet(network.getId(), networkId, subnetCidr);
+        getDriver().createSubnet(networkId, subnetCidr);
 
         return networkId;
+    }
+
+    @Override
+    public void deallocateNetwork(VirtualNetwork network) {
+        String networkId = network.sensors().get(VirtualNetwork.NETWORK_ID);
+
+        // Delete the network using the SDN driver
+        getDriver().deleteSubnet(networkId);
     }
 
     static {

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/SdnProvider.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/SdnProvider.java
@@ -16,6 +16,7 @@
 package clocker.docker.networking.entity.sdn;
 
 import java.net.InetAddress;
+import java.util.List;
 import java.util.Map;
 
 import clocker.docker.networking.entity.VirtualNetwork;
@@ -28,10 +29,8 @@ import org.apache.brooklyn.api.entity.Group;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
-import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.entity.stock.BasicStartable;
-import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.apache.brooklyn.util.net.Cidr;
 
 /**
@@ -50,8 +49,8 @@ public interface SdnProvider extends BasicStartable, NetworkProvisioningExtensio
             new TypeToken<Map<String, Cidr>>() { }, "sdn.networks.addresses", "Map of network subnets that have been created");
     AttributeSensor<Map<String, VirtualNetwork>> SUBNET_ENTITIES = Sensors.newSensor(
             new TypeToken<Map<String, VirtualNetwork>>() { }, "sdn.networks.entities", "Map of managed network entities that have been created by this SDN");
-    AttributeSensor<Map<String, Integer>> SUBNET_ADDRESS_ALLOCATIONS = Sensors.newSensor(
-            new TypeToken<Map<String, Integer>>() { }, "sdn.networks.addresses.allocated", "Map of allocated address count on network subnets");
+    AttributeSensor<Map<String, List<InetAddress>>> SUBNET_ADDRESS_ALLOCATIONS = Sensors.newSensor(
+            new TypeToken<Map<String, List<InetAddress>>>() { }, "sdn.networks.addresses.allocated", "Map of allocated address count on network subnets");
 
     AttributeSensor<Multimap<String, InetAddress>> CONTAINER_ADDRESSES = Sensors.newSensor(
             new TypeToken<Multimap<String, InetAddress>>() { }, "sdn.container.addresses", "Map of container ID to IP addresses on network");
@@ -61,19 +60,21 @@ public interface SdnProvider extends BasicStartable, NetworkProvisioningExtensio
 
     /* IP address management. */
 
-    InetAddress getNextContainerAddress(String networkId);
+    InetAddress getNextContainerAddress(String subnetId);
+
+    void recordContainerAddress(String subnetId, InetAddress address);
+
+    void associateContainerAddress(String containerId, InetAddress address);
 
     /* Access for network subnet CIDRs this SDN provder manages. */
 
-    Cidr getNextSubnetCidr(String networkId);
+    Cidr getNextSubnetCidr(String subnetId);
 
     Cidr getNextSubnetCidr();
 
-    void recordSubnetCidr(String networkId, Cidr subnetCidr);
+    void recordSubnetCidr(String subnetId, Cidr subnetCidr);
 
-    void recordSubnetCidr(String networkId, Cidr subnetCidr, int allocated);
-
-    Cidr getSubnetCidr(String networkId);
+    Cidr getSubnetCidr(String subnetId);
 
     Object getNetworkMutex();
 

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/calico/CalicoNetwork.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/calico/CalicoNetwork.java
@@ -20,12 +20,9 @@ import clocker.docker.networking.entity.sdn.DockerSdnProvider;
 import org.apache.brooklyn.api.catalog.Catalog;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.entity.ImplementedBy;
-import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
-import org.apache.brooklyn.core.sensor.Sensors;
-import org.apache.brooklyn.entity.nosql.etcd.EtcdCluster;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 
 /**
@@ -42,14 +39,5 @@ public interface CalicoNetwork extends DockerSdnProvider {
 
     ConfigKey<Boolean> USE_IPIP = ConfigKeys.newBooleanConfigKey("calico.ipip", "Use the IPIP protocol for inter-VM traffic", Boolean.TRUE);
     ConfigKey<Boolean> USE_NAT = ConfigKeys.newBooleanConfigKey("calico.nat", "Use NAT for outgoing traffic", Boolean.TRUE);
-
-    @SetFromFlag("etcdVersion")
-    ConfigKey<String> ETCD_VERSION = ConfigKeys.newStringConfigKey("etcd.version", "The Etcd version number", "2.3.1");
-
-    ConfigKey<Boolean> EXTERNAL_ETCD_CLUSTER = ConfigKeys.newBooleanConfigKey("calico.etcd.external", "Whether to use an external Etcd cluster", Boolean.FALSE);
-    ConfigKey<Integer> EXTERNAL_ETCD_INITIAL_SIZE = ConfigKeys.newIntegerConfigKey("calico.etcd.external.initialSize", "The initial size of the external Etcd cluster");
-    AttributeSensorAndConfigKey<String, String> EXTERNAL_ETCD_URL = ConfigKeys.newStringSensorAndConfigKey("calico.etcd.external.url", "The URL for the external Etcd cluster (if configured, no cluster will be provisioned)");
-
-    AttributeSensor<EtcdCluster> ETCD_CLUSTER = Sensors.newSensor(EtcdCluster.class, "etcd.cluster", "The EtcdCluster entity for storing state");
 
 }

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/calico/CalicoNetwork.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/calico/CalicoNetwork.java
@@ -36,7 +36,7 @@ import org.apache.brooklyn.util.core.flags.SetFromFlag;
 public interface CalicoNetwork extends DockerSdnProvider {
 
     @SetFromFlag("calicoVersion")
-    ConfigKey<String> CALICO_VERSION = ConfigKeys.newStringConfigKey("calico.version", "The Calico SDN version number", "0.4.9");
+    ConfigKey<String> CALICO_VERSION = ConfigKeys.newStringConfigKey("calico.version", "The Calico SDN version number", "0.19.0");
 
     AttributeSensorAndConfigKey<EntitySpec<?>, EntitySpec<?>> CALICO_NODE_SPEC = ConfigKeys.newSensorAndConfigKeyWithDefault(SDN_AGENT_SPEC, EntitySpec.create(CalicoNode.class));
 
@@ -44,7 +44,7 @@ public interface CalicoNetwork extends DockerSdnProvider {
     ConfigKey<Boolean> USE_NAT = ConfigKeys.newBooleanConfigKey("calico.nat", "Use NAT for outgoing traffic", Boolean.TRUE);
 
     @SetFromFlag("etcdVersion")
-    ConfigKey<String> ETCD_VERSION = ConfigKeys.newStringConfigKey("etcd.version", "The Etcd version number", "2.0.11");
+    ConfigKey<String> ETCD_VERSION = ConfigKeys.newStringConfigKey("etcd.version", "The Etcd version number", "2.3.1");
 
     ConfigKey<Boolean> EXTERNAL_ETCD_CLUSTER = ConfigKeys.newBooleanConfigKey("calico.etcd.external", "Whether to use an external Etcd cluster", Boolean.FALSE);
     ConfigKey<Integer> EXTERNAL_ETCD_INITIAL_SIZE = ConfigKeys.newIntegerConfigKey("calico.etcd.external.initialSize", "The initial size of the external Etcd cluster");

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/calico/CalicoNetworkImpl.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/calico/CalicoNetworkImpl.java
@@ -111,14 +111,6 @@ public class CalicoNetworkImpl extends SdnProviderImpl implements CalicoNetwork 
                 .cidrBlock(Cidr.UNIVERSAL.toString()) // TODO could be tighter restricted?
                 .build();
         permissions.add(etcdPeerTcpPort);
-        Integer powerstripPort = config().get(CalicoNode.POWERSTRIP_PORT);
-        IpPermission powerstripTcpPort = IpPermission.builder()
-                .ipProtocol(IpProtocol.TCP)
-                .fromPort(powerstripPort)
-                .toPort(powerstripPort)
-                .cidrBlock(source)
-                .build();
-        permissions.add(powerstripTcpPort);
         return permissions;
     }
 

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/calico/CalicoNetworkImpl.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/calico/CalicoNetworkImpl.java
@@ -27,28 +27,17 @@ import clocker.docker.networking.entity.sdn.SdnAgent;
 import clocker.docker.networking.entity.sdn.SdnProviderImpl;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 
 import org.jclouds.net.domain.IpPermission;
-import org.jclouds.net.domain.IpProtocol;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
-import org.apache.brooklyn.api.location.PortRange;
-import org.apache.brooklyn.core.config.render.RendererHints;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
-import org.apache.brooklyn.entity.group.Cluster;
-import org.apache.brooklyn.entity.group.DynamicCluster;
-import org.apache.brooklyn.entity.nosql.etcd.EtcdCluster;
-import org.apache.brooklyn.entity.nosql.etcd.EtcdNode;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
-import org.apache.brooklyn.entity.stock.DelegateEntity;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.collections.MutableList;
-import org.apache.brooklyn.util.collections.QuorumCheck.QuorumChecks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
-import org.apache.brooklyn.util.net.Cidr;
 import org.apache.brooklyn.util.text.Strings;
 
 public class CalicoNetworkImpl extends SdnProviderImpl implements CalicoNetwork {
@@ -59,24 +48,6 @@ public class CalicoNetworkImpl extends SdnProviderImpl implements CalicoNetwork 
     public void init() {
         LOG.info("Starting Calico network id {}", getId());
         super.init();
-
-        EntitySpec<?> etcdNodeSpec = EntitySpec.create(config().get(EtcdCluster.ETCD_NODE_SPEC));
-        String etcdVersion = config().get(ETCD_VERSION);
-        if (Strings.isNonBlank(etcdVersion)) {
-            etcdNodeSpec.configure(SoftwareProcess.SUGGESTED_VERSION, etcdVersion);
-        }
-        sensors().set(EtcdCluster.ETCD_NODE_SPEC, etcdNodeSpec);
-
-        EtcdCluster etcd = addChild(EntitySpec.create(EtcdCluster.class)
-                .configure(Cluster.INITIAL_SIZE, 0)
-                .configure(EtcdCluster.ETCD_NODE_SPEC, etcdNodeSpec)
-                .configure(EtcdCluster.CLUSTER_NAME, "calico")
-                .configure(EtcdCluster.CLUSTER_TOKEN, "etcd-calico")
-                .configure(DynamicCluster.QUARANTINE_FAILED_ENTITIES, true)
-                .configure(DynamicCluster.RUNNING_QUORUM_CHECK, QuorumChecks.atLeastOneUnlessEmpty())
-                .configure(DynamicCluster.UP_QUORUM_CHECK, QuorumChecks.atLeastOneUnlessEmpty())
-                .displayName("Calico Etcd Cluster"));
-        sensors().set(ETCD_CLUSTER, etcd);
 
         EntitySpec<?> agentSpec = EntitySpec.create(config().get(CALICO_NODE_SPEC))
                 .configure(CalicoNode.SDN_PROVIDER, this);
@@ -93,24 +64,6 @@ public class CalicoNetworkImpl extends SdnProviderImpl implements CalicoNetwork 
     @Override
     public Collection<IpPermission> getIpPermissions(String source) {
         Collection<IpPermission> permissions = MutableList.of();
-        PortRange etcdClientPortConfig = config().get(EtcdNode.ETCD_CLIENT_PORT);
-        Integer etcdClientPort = etcdClientPortConfig.iterator().next();
-        IpPermission etcdClientTcpPort = IpPermission.builder()
-                .ipProtocol(IpProtocol.TCP)
-                .fromPort(etcdClientPort)
-                .toPort(etcdClientPort)
-                .cidrBlock(Cidr.UNIVERSAL.toString()) // TODO could be tighter restricted?
-                .build();
-        permissions.add(etcdClientTcpPort);
-        PortRange etcdPeerPortConfig = config().get(EtcdNode.ETCD_PEER_PORT);
-        Integer etcdPeerPort = etcdPeerPortConfig.iterator().next();
-        IpPermission etcdPeerTcpPort = IpPermission.builder()
-                .ipProtocol(IpProtocol.TCP)
-                .fromPort(etcdPeerPort)
-                .toPort(etcdPeerPort)
-                .cidrBlock(Cidr.UNIVERSAL.toString()) // TODO could be tighter restricted?
-                .build();
-        permissions.add(etcdPeerTcpPort);
         return permissions;
     }
 
@@ -134,14 +87,9 @@ public class CalicoNetworkImpl extends SdnProviderImpl implements CalicoNetwork 
     @Override
     public void addHost(DockerHost host) {
         SshMachineLocation machine = host.getDynamicLocation().getMachine();
-
-        EtcdCluster etcd = sensors().get(ETCD_CLUSTER);
-        EtcdNode node = (EtcdNode) etcd.addNode(machine, Maps.newHashMap());
-        node.start(ImmutableList.of(machine));
-
         EntitySpec<?> spec = EntitySpec.create(sensors().get(SDN_AGENT_SPEC))
                 .configure(CalicoNode.DOCKER_HOST, host)
-                .configure(CalicoNode.ETCD_NODE, node);
+                .configure(CalicoNode.ETCD_NODE, host.sensors().get(DockerHost.ETCD_NODE));
         CalicoNode agent = (CalicoNode) getAgents().addChild(spec);
         getAgents().addMember(agent);
         agent.start(ImmutableList.of(machine));
@@ -155,20 +103,10 @@ public class CalicoNetworkImpl extends SdnProviderImpl implements CalicoNetwork 
             LOG.warn("{} cannot find calico service: {}", this, host);
             return;
         }
-
-        EtcdCluster etcd = sensors().get(ETCD_CLUSTER);
-        EtcdNode node = agent.sensors().get(CalicoNode.ETCD_NODE);
-        etcd.removeMember(node);
-        node.stop();
-
         agent.stop();
         getAgents().removeMember(agent);
         Entities.unmanage(agent);
         if (LOG.isDebugEnabled()) LOG.debug("{} removed calico plugin {}", this, agent);
-    }
-
-    static {
-        RendererHints.register(ETCD_CLUSTER, RendererHints.openWithUrl(DelegateEntity.EntityUrl.entityUrl()));
     }
 
 }

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/calico/CalicoNode.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/calico/CalicoNode.java
@@ -32,7 +32,7 @@ import org.apache.brooklyn.util.core.flags.SetFromFlag;
 public interface CalicoNode extends SdnAgent {
 
     @SetFromFlag("version")
-    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "0.4.8");
+    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "0.19.0");
 
     @SetFromFlag("downloadUrl")
     AttributeSensorAndConfigKey<String, String> DOWNLOAD_URL = ConfigKeys.newSensorAndConfigKeyWithDefault(SoftwareProcess.DOWNLOAD_URL,
@@ -40,9 +40,6 @@ public interface CalicoNode extends SdnAgent {
 
     @SetFromFlag("etcdNode")
     AttributeSensorAndConfigKey<EtcdNode, EtcdNode> ETCD_NODE = ConfigKeys.newSensorAndConfigKey(EtcdNode.class,
-            "sdn.calico.etcd.node", "The EtcdNode attached to the same DockerHost as the plugin");
-
-    @SetFromFlag("powerstripPort")
-    ConfigKey<Integer> POWERSTRIP_PORT = ConfigKeys.newIntegerConfigKey("powerstrip.port", "Powerstrip port", 2377);
+            "calico.etcd.node", "The EtcdNode attached to the same DockerHost as the plugin");
 
 }

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/calico/CalicoNodeSshDriver.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/calico/CalicoNodeSshDriver.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import clocker.docker.networking.entity.sdn.DockerNetworkAgentrSshDriver;
+import clocker.docker.networking.entity.sdn.DockerNetworkAgentSshDriver;
 import clocker.docker.networking.entity.sdn.SdnAgent;
 
 import com.google.common.collect.Lists;
@@ -42,7 +42,7 @@ import org.apache.brooklyn.util.net.Cidr;
 import org.apache.brooklyn.util.os.Os;
 import org.apache.brooklyn.util.ssh.BashCommands;
 
-public class CalicoNodeSshDriver extends DockerNetworkAgentrSshDriver implements CalicoNodeDriver {
+public class CalicoNodeSshDriver extends DockerNetworkAgentSshDriver implements CalicoNodeDriver {
 
     private static final Logger LOG = LoggerFactory.getLogger(CalicoNode.class);
 

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/calico/CalicoNodeSshDriver.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/calico/CalicoNodeSshDriver.java
@@ -15,7 +15,6 @@
  */
 package clocker.docker.networking.entity.sdn.calico;
 
-import static org.apache.brooklyn.util.ssh.BashCommands.ok;
 import static org.apache.brooklyn.util.ssh.BashCommands.sudo;
 
 import java.net.InetAddress;
@@ -25,11 +24,9 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import clocker.docker.networking.entity.sdn.DockerNetworkAgentrSshDriver;
 import clocker.docker.networking.entity.sdn.SdnAgent;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Splitter;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
 
@@ -38,23 +35,24 @@ import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.entity.group.AbstractGroup;
 import org.apache.brooklyn.entity.nosql.etcd.EtcdNode;
-import org.apache.brooklyn.entity.software.base.AbstractSoftwareProcessSshDriver;
-import org.apache.brooklyn.entity.software.base.lifecycle.ScriptHelper;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.net.Cidr;
 import org.apache.brooklyn.util.os.Os;
 import org.apache.brooklyn.util.ssh.BashCommands;
-import org.apache.brooklyn.util.text.StringPredicates;
-import org.apache.brooklyn.util.text.Strings;
-import org.apache.brooklyn.util.text.VersionComparator;
 
-public class CalicoNodeSshDriver extends AbstractSoftwareProcessSshDriver implements CalicoNodeDriver {
+public class CalicoNodeSshDriver extends DockerNetworkAgentrSshDriver implements CalicoNodeDriver {
 
     private static final Logger LOG = LoggerFactory.getLogger(CalicoNode.class);
 
     public CalicoNodeSshDriver(EntityLocal entity, SshMachineLocation machine) {
         super(entity, machine);
+    }
+
+    @Override
+    public String getDockerNetworkDriver() {
+        return "calico";
     }
 
     @Override
@@ -92,7 +90,7 @@ public class CalicoNodeSshDriver extends AbstractSoftwareProcessSshDriver implem
 
         newScript(MutableMap.of(USE_PID_FILE, false), LAUNCHING)
                 .updateTaskAndFailOnNonZeroResultCode()
-                .body.append(sudo(String.format("%s node --ip=%s", getCalicoCommand(), address.getHostAddress())))
+                .body.append(sudo(String.format("%s node --libnetwork --ip=%s", getCalicoCommand(), address.getHostAddress())))
                 .execute();
     }
 
@@ -111,91 +109,24 @@ public class CalicoNodeSshDriver extends AbstractSoftwareProcessSshDriver implem
     }
 
     @Override
-    public void createSubnet(String virtualNetworkId, String subnetId, Cidr subnetCidr) {
+    public List<String> getDockerNetworkCreateOpts() {
+        boolean ipip = entity.config().get(CalicoNetwork.USE_IPIP);
+        boolean nat = entity.config().get(CalicoNetwork.USE_NAT);
+        List<String> opts = MutableList.of();
+        if (ipip) opts.add("ipip=true");
+        if (nat) opts.add("nat-outgoing=true");
+        return opts;
+    }
+
+    @Override
+    public void createSubnet(String subnetId, Cidr subnetCidr) {
         boolean ipip = entity.config().get(CalicoNetwork.USE_IPIP);
         boolean nat = entity.config().get(CalicoNetwork.USE_NAT);
         newScript("createSubnet")
                 .body.append(
                         sudo(String.format("%s pool add %s %s %s", getCalicoCommand(), subnetCidr, ipip ? "--ipip" : "", nat ? "--nat-outgoing" : "")))
                 .execute();
-    }
-
-    /** For Calico we use profiles to group containers in networks and add the required IP address to the eth1 calico interface. */
-    @Override
-    public InetAddress attachNetwork(String containerId, String subnetId) {
-        InetAddress address = getEntity().sensors().get(SdnAgent.SDN_PROVIDER).getNextContainerAddress(subnetId);
-
-        // Run some commands to get information about the container network namespace
-        String ipAddrOutput = getEntity().sensors().get(SdnAgent.DOCKER_HOST).execCommand(sudo("ip addr show dev docker0 scope global label docker0"));
-        String dockerIp = Strings.getFirstWordAfter(ipAddrOutput.replace('/', ' '), "inet");
-        String dockerPid = Strings.trimEnd(getEntity().sensors().get(SdnAgent.DOCKER_HOST).runDockerCommand("inspect -f '{{.State.Pid}}' " + containerId));
-        Cidr subnetCidr = getEntity().sensors().get(SdnAgent.SDN_PROVIDER).getSubnetCidr(subnetId);
-        InetAddress agentAddress = getEntity().sensors().get(SdnAgent.SDN_AGENT_ADDRESS);
-
-        // Setup namespace
-        newScript("setupNamespace")
-                .body.append( // Idempotent
-                        sudo("mkdir -p /var/run/netns"),
-                        ok(sudo(String.format("ln -s /proc/%s/ns/net /var/run/netns/%s", dockerPid, dockerPid))))
-                .execute();
-
-        // Try and find out if the container has already been added to Calico
-        ScriptHelper checkEndpointId = newScript("checkEndpointId")
-                .body.append(sudo(String.format("%s container %s %s show", getCalicoCommand(), containerId, isVersionAbove("0.4.9") ? "endpoint" : "endpoint-id")))
-                .noExtraOutput()
-                .gatherOutput();
-        checkEndpointId.execute();
-        String stdout = checkEndpointId.getResultStdout();
-        boolean containerAdded = stdout.contains(containerId);
-
-        if (!containerAdded) {
-            // Add the container
-            newScript("addContainer")
-                    .body.append(sudo(String.format("%s container add %s %s", getCalicoCommand(), containerId, address.getHostAddress())))
-                    .execute();
-
-            // Determine its endpoint ID
-            ScriptHelper getEndpointId = newScript("getEndpointId")
-                    .body.append(sudo(String.format("%s container %s %s show", getCalicoCommand(), containerId, isVersionAbove("0.4.9") ? "endpoint" : "endpoint-id")))
-                    .noExtraOutput()
-                    .gatherOutput();
-            getEndpointId.execute();
-            Optional<String> endpointDetails = Iterables.tryFind(Splitter.on('\n').split(getEndpointId.getResultStdout()), StringPredicates.containsLiteral(containerId));
-            if (!endpointDetails.isPresent()) {
-                throw new IllegalStateException(String.format("Error setting up Calico for %s", containerId));
-            }
-            String endpointId = Iterables.get(Splitter.on('|').trimResults().split(endpointDetails.get()), 4);
-            LOG.warn("Endpoint is {} from: {}", endpointId, endpointDetails.get());
-
-            // Add to the application profile
-            newScript("addCalico")
-                    .body.append( // Idempotent
-                            sudo(String.format("%s profile add %s", getCalicoCommand(), subnetId)),
-                            sudo(String.format("%s endpoint %s profile append %s", getCalicoCommand(), endpointId, subnetId)))
-                    .execute();
-
-            // Add new routes
-            newScript("addRoutes")
-                    .body.append(
-                            sudo(String.format("ip netns exec %s ip route del default", dockerPid)),
-                            sudo(String.format("ip netns exec %s ip route add default via %s", dockerPid, dockerIp)),
-                            sudo(String.format("ip netns exec %s ip route add %s via %s", dockerPid, subnetCidr.toString(), agentAddress.getHostAddress())))
-                    .execute();
-        } else {
-            // Add extra network and address
-            newScript("addAddress")
-                    .body.append(
-                            sudo(String.format("%s container %s ip add %s --interface=eth1", getCalicoCommand(), containerId, address.getHostAddress())),
-                            sudo(String.format("ip netns exec %s ip route add %s via %s", dockerPid, subnetCidr.toString(), agentAddress.getHostAddress())))
-                    .execute();
-        }
-
-        return address;
-    }
-
-    private boolean isVersionAbove(String target) {
-        int result = VersionComparator.getInstance().compare(getVersion(), target);
-        return result > 0;
+        super.createSubnet(subnetId, subnetCidr);
     }
 
     @Override

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/overlay/OverlayNetwork.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/overlay/OverlayNetwork.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2016 by Cloudsoft Corporation Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package clocker.docker.networking.entity.sdn.overlay;
+
+import clocker.docker.networking.entity.sdn.DockerSdnProvider;
+
+import org.apache.brooklyn.api.catalog.Catalog;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
+
+/**
+ * A collection of machines running Docker.
+ */
+@Catalog(name = "Overlay Network", description = "Docker overlay networking for SDN", iconUrl = "classpath://docker-logo.png")
+@ImplementedBy(OverlayNetworkImpl.class)
+public interface OverlayNetwork extends DockerSdnProvider {
+
+    AttributeSensorAndConfigKey<EntitySpec<?>, EntitySpec<?>> OVERLAY_AGENT_SPEC = ConfigKeys.newSensorAndConfigKeyWithDefault(SDN_AGENT_SPEC, EntitySpec.create(OverlayPlugin.class));
+
+}

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/overlay/OverlayNetworkImpl.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/overlay/OverlayNetworkImpl.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2014-2016 by Cloudsoft Corporation Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package clocker.docker.networking.entity.sdn.overlay;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collection;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import clocker.docker.entity.DockerHost;
+import clocker.docker.networking.entity.sdn.SdnAgent;
+import clocker.docker.networking.entity.sdn.SdnProviderImpl;
+
+import com.google.common.collect.ImmutableList;
+
+import org.jclouds.net.domain.IpPermission;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+
+public class OverlayNetworkImpl extends SdnProviderImpl implements OverlayNetwork {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OverlayNetwork.class);
+
+    @Override
+    public String getIconUrl() { return "classpath://docker-logo.png"; }
+
+    @Override
+    public Collection<IpPermission> getIpPermissions(String source) {
+        Collection<IpPermission> permissions = MutableList.of();
+        return permissions;
+    }
+
+    @Override
+    public InetAddress getNextAgentAddress(String agentId) {
+        Entity agent = getManagementContext().getEntityManager().getEntity(agentId);
+        String address = agent.sensors().get(OverlayPlugin.DOCKER_HOST).sensors().get(Attributes.SUBNET_ADDRESS);
+        try {
+            return InetAddress.getByName(address);
+        } catch (UnknownHostException uhe) {
+            throw Exceptions.propagate(uhe);
+        }
+    }
+
+    @Override
+    public void rebind() {
+        super.rebind();
+    }
+
+    @Override
+    public void addHost(DockerHost host) {
+        SshMachineLocation machine = host.getDynamicLocation().getMachine();
+        EntitySpec<?> spec = EntitySpec.create(sensors().get(SDN_AGENT_SPEC))
+                .configure(OverlayPlugin.DOCKER_HOST, host);
+        OverlayPlugin agent = (OverlayPlugin) getAgents().addChild(spec);
+        getAgents().addMember(agent);
+        agent.start(ImmutableList.of(machine));
+        if (LOG.isDebugEnabled()) LOG.debug("{} added overlay plugin {}", this, agent);
+    }
+
+    @Override
+    public void removeHost(DockerHost host) {
+        SdnAgent agent = host.sensors().get(SdnAgent.SDN_AGENT);
+        if (agent == null) {
+            LOG.warn("{} cannot find overlay service: {}", this, host);
+            return;
+        }
+        agent.stop();
+        getAgents().removeMember(agent);
+        Entities.unmanage(agent);
+        if (LOG.isDebugEnabled()) LOG.debug("{} removed overlay plugin {}", this, agent);
+    }
+
+}

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/overlay/OverlayPlugin.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/overlay/OverlayPlugin.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014-2016 by Cloudsoft Corporation Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package clocker.docker.networking.entity.sdn.overlay;
+
+import clocker.docker.networking.entity.sdn.SdnAgent;
+
+import org.apache.brooklyn.api.entity.ImplementedBy;
+
+/**
+ * The Overlay network plugin
+ */
+@ImplementedBy(OverlayPluginImpl.class)
+public interface OverlayPlugin extends SdnAgent {
+
+}

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/overlay/OverlayPluginDriver.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/overlay/OverlayPluginDriver.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014-2016 by Cloudsoft Corporation Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package clocker.docker.networking.entity.sdn.overlay;
+
+import clocker.docker.networking.entity.sdn.DockerNetworkAgentDriver;
+
+public interface OverlayPluginDriver extends DockerNetworkAgentDriver {
+
+}

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/overlay/OverlayPluginImpl.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/overlay/OverlayPluginImpl.java
@@ -13,38 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package clocker.docker.networking.entity.sdn.calico;
+package clocker.docker.networking.entity.sdn.overlay;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import clocker.docker.entity.container.DockerContainer;
 import clocker.docker.networking.entity.sdn.SdnAgentImpl;
 
-import org.apache.brooklyn.core.config.render.RendererHints;
-import org.apache.brooklyn.core.feed.ConfigToAttributes;
-import org.apache.brooklyn.entity.stock.DelegateEntity;
-
 /**
- * Calico node services running in {@link DockerContainer containers}.
+ * The Docker engine running the overlay network plugin.
  */
-public class CalicoNodeImpl extends SdnAgentImpl implements CalicoNode {
+public class OverlayPluginImpl extends SdnAgentImpl implements OverlayPlugin {
 
-    private static final Logger LOG = LoggerFactory.getLogger(CalicoNode.class);
-
-    public void init() {
-        super.init();
-
-        ConfigToAttributes.apply(this, ETCD_NODE);
-    }
+    private static final Logger LOG = LoggerFactory.getLogger(OverlayPlugin.class);
 
     @Override
     public Class getDriverInterface() {
-        return CalicoNodeDriver.class;
-    }
-
-    static {
-        RendererHints.register(ETCD_NODE, RendererHints.openWithUrl(DelegateEntity.EntityUrl.entityUrl()));
+        return OverlayPluginDriver.class;
     }
 
 }

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/overlay/OverlayPluginSshDriver.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/overlay/OverlayPluginSshDriver.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014-2016 by Cloudsoft Corporation Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package clocker.docker.networking.entity.sdn.overlay;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import clocker.docker.networking.entity.sdn.DockerNetworkAgentrSshDriver;
+
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.location.ssh.SshMachineLocation;
+
+public class OverlayPluginSshDriver extends DockerNetworkAgentrSshDriver implements OverlayPluginDriver {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OverlayPlugin.class);
+
+    public OverlayPluginSshDriver(EntityLocal entity, SshMachineLocation machine) {
+        super(entity, machine);
+    }
+
+    @Override
+    public String getDockerNetworkDriver() {
+        return "overlay";
+    }
+
+    @Override
+    public void install() {
+        newScript(INSTALLING).execute();
+    }
+
+    @Override
+    public void customize() {
+        newScript(CUSTOMIZING).execute();
+    }
+
+    @Override
+    public void launch() {
+        newScript(LAUNCHING).execute();
+    }
+
+    @Override
+    public boolean isRunning() {
+        return true;
+    }
+
+    @Override
+    public void stop() {
+    }
+
+}

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/overlay/OverlayPluginSshDriver.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/overlay/OverlayPluginSshDriver.java
@@ -18,12 +18,12 @@ package clocker.docker.networking.entity.sdn.overlay;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import clocker.docker.networking.entity.sdn.DockerNetworkAgentrSshDriver;
+import clocker.docker.networking.entity.sdn.DockerNetworkAgentSshDriver;
 
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 
-public class OverlayPluginSshDriver extends DockerNetworkAgentrSshDriver implements OverlayPluginDriver {
+public class OverlayPluginSshDriver extends DockerNetworkAgentSshDriver implements OverlayPluginDriver {
 
     private static final Logger LOG = LoggerFactory.getLogger(OverlayPlugin.class);
 

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/util/SdnAttributes.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/util/SdnAttributes.java
@@ -34,8 +34,6 @@ import org.apache.brooklyn.core.sensor.Sensors;
  */
 public class SdnAttributes {
 
-    public static final String DEFAULT_NETWORK = "bridge";
-
     public static final ConfigKey<Collection<String>> NETWORK_LIST = ConfigKeys.newConfigKey(
             new TypeToken<Collection<String>>() { }, "network.list", "Collection of extra networks to create for an entity", Collections.<String>emptyList());
 

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/util/SdnAttributes.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/util/SdnAttributes.java
@@ -34,6 +34,8 @@ import org.apache.brooklyn.core.sensor.Sensors;
  */
 public class SdnAttributes {
 
+    public static final String DEFAULT_NETWORK = "bridge";
+
     public static final ConfigKey<Collection<String>> NETWORK_LIST = ConfigKeys.newConfigKey(
             new TypeToken<Collection<String>>() { }, "network.list", "Collection of extra networks to create for an entity", Collections.<String>emptyList());
 
@@ -44,7 +46,12 @@ public class SdnAttributes {
 
     public static final AttributeSensorAndConfigKey<Entity, Entity> SDN_PROVIDER = ConfigKeys.newSensorAndConfigKey(Entity.class, "sdn.provider.network", "SDN provider network entity");
 
+    public static final AttributeSensor<String> INITIAL_ATTACHED_NETWORK = Sensors.newStringSensor(
+            "sdn.networks.initial", "The first network that an entity is attached to");
+
     public static final AttributeSensor<List<String>> ATTACHED_NETWORKS = Sensors.newSensor(new TypeToken<List<String>>() { },
             "sdn.networks.attached", "The list of networks that an entity is attached to");
+
+    public static final ConfigKey<Boolean> CREATE_APPLICATION_NETWORK = ConfigKeys.newBooleanConfigKey("sdn.applicationNetwork.create", "Create a new network for each application using its ID", Boolean.TRUE);
 
 }

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/weave/WeaveRouterDriver.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/weave/WeaveRouterDriver.java
@@ -15,8 +15,8 @@
  */
 package clocker.docker.networking.entity.sdn.weave;
 
-import clocker.docker.networking.entity.sdn.SdnAgentDriver;
+import clocker.docker.networking.entity.sdn.DockerNetworkAgentDriver;
 
-public interface WeaveRouterDriver extends SdnAgentDriver {
+public interface WeaveRouterDriver extends DockerNetworkAgentDriver {
 
 }

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/weave/WeaveRouterSshDriver.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/weave/WeaveRouterSshDriver.java
@@ -25,7 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import clocker.docker.entity.DockerInfrastructure;
-import clocker.docker.networking.entity.sdn.DockerNetworkAgentrSshDriver;
+import clocker.docker.networking.entity.sdn.DockerNetworkAgentSshDriver;
 import clocker.docker.networking.entity.sdn.SdnAgent;
 import clocker.docker.networking.entity.sdn.SdnProvider;
 
@@ -41,7 +41,7 @@ import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.os.Os;
 import org.apache.brooklyn.util.ssh.BashCommands;
 
-public class WeaveRouterSshDriver extends DockerNetworkAgentrSshDriver implements WeaveRouterDriver {
+public class WeaveRouterSshDriver extends DockerNetworkAgentSshDriver implements WeaveRouterDriver {
 
     private static final Logger LOG = LoggerFactory.getLogger(WeaveRouter.class);
 

--- a/docker/src/main/java/clocker/docker/networking/entity/sdn/weave/WeaveRouterSshDriver.java
+++ b/docker/src/main/java/clocker/docker/networking/entity/sdn/weave/WeaveRouterSshDriver.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import clocker.docker.entity.DockerInfrastructure;
+import clocker.docker.networking.entity.sdn.DockerNetworkAgentrSshDriver;
 import clocker.docker.networking.entity.sdn.SdnAgent;
 import clocker.docker.networking.entity.sdn.SdnProvider;
 
@@ -35,20 +36,22 @@ import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.entity.group.AbstractGroup;
-import org.apache.brooklyn.entity.software.base.AbstractSoftwareProcessSshDriver;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.collections.MutableMap;
-import org.apache.brooklyn.util.core.task.Tasks;
-import org.apache.brooklyn.util.net.Cidr;
 import org.apache.brooklyn.util.os.Os;
 import org.apache.brooklyn.util.ssh.BashCommands;
 
-public class WeaveRouterSshDriver extends AbstractSoftwareProcessSshDriver implements WeaveRouterDriver {
+public class WeaveRouterSshDriver extends DockerNetworkAgentrSshDriver implements WeaveRouterDriver {
 
     private static final Logger LOG = LoggerFactory.getLogger(WeaveRouter.class);
 
     public WeaveRouterSshDriver(EntityLocal entity, SshMachineLocation machine) {
         super(entity, machine);
+    }
+
+    @Override
+    public String getDockerNetworkDriver() {
+        return "weave";
     }
 
     public String getWeaveCommand() {
@@ -125,28 +128,10 @@ public class WeaveRouterSshDriver extends AbstractSoftwareProcessSshDriver imple
     }
 
     @Override
-    public void createSubnet(String svirtualNetworkId, String subnetId, Cidr subnetCidr) {
-        LOG.debug("Nothing to do for Weave subnet creation");
-    }
-
-    @Override
-    public InetAddress attachNetwork(String containerId, String subnetId) {
-        Tasks.setBlockingDetails(String.format("Attach %s to %s", containerId, subnetId));
-        try {
-            Cidr cidr = getEntity().sensors().get(SdnAgent.SDN_PROVIDER).getSubnetCidr(subnetId);
-            InetAddress address = getEntity().sensors().get(SdnAgent.SDN_PROVIDER).getNextContainerAddress(subnetId);
-            execute(BashCommands.sudo(String.format("%s attach %s/%d %s",
-                    getWeaveCommand(), address.getHostAddress(), cidr.getLength(), containerId)), "attach-network");
-            return address;
-        } finally {
-            Tasks.resetBlockingDetails();
-        }
-    }
-
-    @Override
     public Map<String, String> getShellEnvironment() {
         ImmutableMap.Builder<String, String> builder = ImmutableMap.<String, String> builder()
                 .putAll(super.getShellEnvironment())
+                .put("CHECKPOINT_DISABLE", "1")
                 .put("WEAVE_VERSION", entity.config().get(WeaveRouter.SUGGESTED_VERSION))
                 .put("VERSION", entity.config().get(WeaveRouter.SUGGESTED_VERSION));
         return builder.build();

--- a/extras/src/main/java/org/apache/brooklyn/entity/nosql/etcd/EtcdNode.java
+++ b/extras/src/main/java/org/apache/brooklyn/entity/nosql/etcd/EtcdNode.java
@@ -39,7 +39,7 @@ import org.apache.brooklyn.util.time.Duration;
 public interface EtcdNode extends SoftwareProcess {
 
     @SetFromFlag("version")
-    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "2.0.11");
+    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "2.3.1");
 
     @SetFromFlag("startTimeout")
     ConfigKey<Duration> START_TIMEOUT = ConfigKeys.newConfigKeyWithDefault(BrooklynConfigKeys.START_TIMEOUT, Duration.minutes(10));

--- a/patches/README.md
+++ b/patches/README.md
@@ -56,3 +56,15 @@ for full code changes.
 
 - [`DockerTemplateOptions.java`](./src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java)
 - [`NullSafeCopies.java`](./src/main/java/org/jclouds/docker/internal/NullSafeCopies.java)
+
+## Backport from 2.0.0 for Docker
+
+Backports changes from the master 2.0.0-SNAPSHOT branch of the driver. Add
+`OpenStdin` configuration to `DockerTemplateOptions` and set all port bindings
+explicitly on container creation, as required for Docker 1.10 and above.
+
+See [jclouds/jclouds-labs#264](https://github.com/jclouds/jclouds-labs/pull/264)
+for full code changes.
+
+- [`DockerTemplateOptions.java`](./src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java)
+- [`DockerComputeServiceAdapter.java`](./src/main/java/org/jclouds/docker/compute/strategy/DockerComputeServiceAdapter.java)

--- a/patches/src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java
+++ b/patches/src/main/java/org/jclouds/docker/compute/options/DockerTemplateOptions.java
@@ -95,6 +95,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
    protected Map<String, String> extraHosts = ImmutableMap.of();
    protected List<String> volumesFrom = ImmutableList.of();
    protected boolean privileged;
+   protected boolean openStdin;
    protected Config.Builder configBuilder;
 
    @Override
@@ -122,6 +123,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
          eTo.extraHosts(extraHosts);
          eTo.volumesFrom(volumesFrom);
          eTo.privileged(privileged);
+         eTo.openStdin(openStdin);
          eTo.configBuilder(configBuilder);
       }
    }
@@ -147,6 +149,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
               equal(this.extraHosts, that.extraHosts) &&
               equal(this.volumesFrom, that.volumesFrom) &&
               equal(this.privileged, that.privileged) &&
+              equal(this.openStdin, that.openStdin) &&
               buildersEqual(this.configBuilder, that.configBuilder);
    }
 
@@ -161,7 +164,7 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
    @Override
    public int hashCode() {
       return Objects.hashCode(super.hashCode(), volumes, hostname, dns, memory, entrypoint, commands, cpuShares, env,
-            portBindings, extraHosts, configBuilder);
+            portBindings, extraHosts, volumesFrom, privileged, openStdin, configBuilder);
    }
 
    @Override
@@ -179,6 +182,8 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
               .add("networkMode", networkMode)
               .add("extraHosts", extraHosts)
               .add("volumesFrom", volumesFrom)
+              .add("privileged", privileged)
+              .add("openStdin", openStdin)
               .add("configBuilder", configBuilder)
               .toString();
    }
@@ -305,6 +310,17 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
    }
 
    /**
+    * Keep {@code STDIN} open when running interactive workloads in the container.
+    *
+    * @param openStdin Whether the container should keep STDIN open
+    * @return this instance
+    */
+   public DockerTemplateOptions openStdin(boolean openStdin) {
+      this.openStdin = openStdin;
+      return this;
+   }
+
+   /**
     * This method sets Config.Builder configuration object, which can be used as
     * a replacement for all the other settings from this class. Some values in
     * the provided Config.Builder instance (the image name for instance) can be
@@ -346,6 +362,8 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
    public Map<String, String> getExtraHosts() { return extraHosts; }
 
    public boolean getPrivileged() { return privileged; }
+
+   public boolean getOpenStdin() { return openStdin; }
 
    public Config.Builder getConfigBuilder() { return configBuilder; }
 
@@ -477,6 +495,14 @@ public class DockerTemplateOptions extends TemplateOptions implements Cloneable 
       public static DockerTemplateOptions privileged(boolean privileged) {
          DockerTemplateOptions options = new DockerTemplateOptions();
          return options.privileged(privileged);
+      }
+
+      /**
+       * @see DockerTemplateOptions#openStdin(boolean)
+       */
+      public static DockerTemplateOptions openStdin(boolean openStdin) {
+         DockerTemplateOptions options = new DockerTemplateOptions();
+         return options.openStdin(openStdin);
       }
 
       /**

--- a/patches/src/main/java/org/jclouds/docker/compute/strategy/DockerComputeServiceAdapter.java
+++ b/patches/src/main/java/org/jclouds/docker/compute/strategy/DockerComputeServiceAdapter.java
@@ -98,6 +98,7 @@ public class DockerComputeServiceAdapter implements
          containerConfigBuilder.memory(templateOptions.getMemory());
          containerConfigBuilder.hostname(templateOptions.getHostname());
          containerConfigBuilder.cpuShares(templateOptions.getCpuShares());
+         containerConfigBuilder.openStdin(templateOptions.getOpenStdin());
          containerConfigBuilder.env(templateOptions.getEnv());
 
          if (!templateOptions.getVolumes().isEmpty()) {


### PR DESCRIPTION
This upgrades Docker networking support to use the [libnetwork](https://github.com/docker/libnetwork) plugin ecosystem, which gives Clocker a lot more flexibility in terms of SDN usage. 

- Upgrades Calico to v0.19.0 release
- Add libnetwork support for Docker
- Enables Docker clustering with etcd
- Created generic parent for Docker libnetwork plugin agents
- Initial implementation of Clocker SDN for Calico and Weave
- Docker overlay multi-host network support
- Isolated bridge network per application deployed