### PR TITLE
Issue #303: fixes node.js use of “env” config

### DIFF
--- a/dist/src/main/assembly/conf/brooklyn/default.catalog.bom
+++ b/dist/src/main/assembly/conf/brooklyn/default.catalog.bom
@@ -360,7 +360,7 @@ brooklyn.catalog:
             - redis
             - redis-url
             - connect
-            docker.container.environment:
+            env:
               REDISTOGO_URL: >
                 $brooklyn:formatString("redis://%s:%d/",
                 component("redis").attributeWhenReady("host.subnet.hostname"),

--- a/dist/src/main/assembly/files/blueprints/nodejs-todo.yaml
+++ b/dist/src/main/assembly/files/blueprints/nodejs-todo.yaml
@@ -47,7 +47,7 @@ services:
     - redis
     - redis-url
     - connect
-    docker.container.environment:
+    env:
       REDISTOGO_URL: >
         $brooklyn:formatString("redis://%s:%d/",
         component("redis").attributeWhenReady("host.subnet.hostname"),


### PR DESCRIPTION
Note this isn't yet sufficient to get node.js demo working. The network to which the containers are added is case-sensitive, but we don't treat it so. I believe that @grkvlt is fixing that.