### PR TITLE
Add a Riak on docker-cloud-calico example

### DIFF
--- a/dist/src/test/resources/quality_assurance/deploy_riak_cluster.yaml
+++ b/dist/src/test/resources/quality_assurance/deploy_riak_cluster.yaml
@@ -1,0 +1,36 @@
+brooklyn.catalog:
+  id: simple-riak-test
+  version: 1.2.0-SNAPSHOT # CLOCKER_VERSION
+  name: Simple Riak Test
+  itemType: template
+  item:
+    services:
+    - type: org.apache.brooklyn.test.framework.InfrastructureDeploymentTestCase
+      brooklyn.config:
+        infrastructure.deployment.location.sensor: entity.dynamicLocation
+        infrastructure.deployment.spec:
+          $brooklyn:entitySpec:
+            type: docker-cloud-calico:1.2.0-SNAPSHOT # CLOCKER_VERSION
+            id: infrastructure
+            brooklyn.config:
+              entity.dynamicLocation.name: my-docker-cloud
+              docker.host.cluster.initial.size: 2
+        infrastructure.deployment.entity.specs:
+          - $brooklyn:entitySpec:
+              - type: org.apache.brooklyn.entity.nosql.riak.RiakCluster
+                id: RiakServer
+      brooklyn.children:
+      - type: org.apache.brooklyn.test.framework.TestSensor
+        name: Check infrastructure isUp
+        targetId: infrastructure
+        sensor: service.isUp
+        timeout: 10m
+        assert:
+        - equals: true
+      - type: org.apache.brooklyn.test.framework.TestSensor
+        name: Check Riak isUp
+        targetId: RiakServer
+        sensor: service.isUp
+        timeout: 10m
+        assert:
+        - equals: true


### PR DESCRIPTION
Adds a blueprint to deploy a RiakCluster entity on docker-cloud-calico for test purposes.