### PR TITLE
install curl with docker engine

### DIFF
--- a/common/src/main/resources/docker/docker.bom
+++ b/common/src/main/resources/docker/docker.bom
@@ -101,6 +101,8 @@ brooklyn.catalog:
 
           sudo yum -y update
 
+          sudo yum install -y curl
+
           echo "[CLOCKER] Configuring package manager"
           if [[ "${DOCKER_REPOSITORY_URL}" && "${DOCKER_GPG_KEY_URL}" ]] ; then
             # Commercially Supported Docker Engine


### PR DESCRIPTION
A number of the blueprints that depend on docker-engine
require curl.  So far it has been assumed to be available
but this is probably not safe.