### PR TITLE
Swarm manager load balancer fix

### DIFF
--- a/swarm/src/main/resources/swarm/swarm.bom
+++ b/swarm/src/main/resources/swarm/swarm.bom
@@ -253,7 +253,8 @@ brooklyn.catalog:
                 shell.env:
                   SWARM_ENDPOINTS:
                     $brooklyn:attributeWhenReady("swarm.endpoints")
-                command: |
+                command: |                  
+                  cd ${RUN_DIR}
                   cat > servers.conf <<-EOF
                   backend servers
                     balance roundrobin
@@ -325,6 +326,8 @@ brooklyn.catalog:
                 type: docker-swarm-manager
                 id: swarm-manager
                 name: "swarm-manager"
+                brooklyn.config:
+                    provision.latch: $brooklyn:entity("swarm-manager-load-balancer").attributeWhenReady("service.isUp")
 
         - type: cluster
           id: docker-swarm-nodes


### PR DESCRIPTION
Added a latch, to prevent the swarm managers from starting until the load balancer has started.
This is because the load balancer is only re-configured when a swarm manager is added to the cluster- so we need to make sure the balancer is up first.

Also added an explicit CD to the RUN_DIR when we are configuring swarm