### PR TITLE
Increase etcd default

### DIFF
--- a/swarm/src/main/resources/swarm/swarm.bom
+++ b/swarm/src/main/resources/swarm/swarm.bom
@@ -53,7 +53,7 @@ brooklyn.catalog:
           description: |
             Size of the etcd cluster when created initially
           type: integer
-          default: 1
+          default: 2
         - name: swarm.sharedsecuritygroup.create
           label: "Create Swarm SharedSecurityGroup"
           description: |

--- a/swarm/src/main/resources/swarm/swarm.bom
+++ b/swarm/src/main/resources/swarm/swarm.bom
@@ -53,7 +53,7 @@ brooklyn.catalog:
           description: |
             Size of the etcd cluster when created initially
           type: integer
-          default: 2
+          default: 3
         - name: swarm.sharedsecuritygroup.create
           label: "Create Swarm SharedSecurityGroup"
           description: |


### PR DESCRIPTION
The default of `1` can intermittently break, so up it to `3` so the average user will not hit this. A note to fix it has been made elsewhere