### PR TITLE
Fix race condition in configureSwarm effector

### DIFF
--- a/common/src/main/resources/common/common.bom
+++ b/common/src/main/resources/common/common.bom
@@ -198,8 +198,11 @@ brooklyn.catalog:
                 balance roundrobin
               EOF
               for endpoint in $(echo ${HAPROXY_ENDPOINTS} | tr ',' ' ') ; do
-                echo "  server manager$((++n)) ${endpoint} maxconn 32 ssl \
-                  ca-file ${RUN_DIR}/ca.pem crt ${RUN_DIR}/cert.pem" >> ${RUN_DIR}/servers.conf
+                if [ "${HAPROXY_PROTOCOL}" == "http" ]; then
+                  echo "  server master$((++n)) ${endpoint} check" >> ${RUN_DIR}/servers.conf
+                else
+                  echo "  server manager$((++n)) ${endpoint} maxconn 32 ssl ca-file ${RUN_DIR}/ca.pem crt ${RUN_DIR}/cert.pem" >> ${RUN_DIR}/servers.conf
+                fi
               done
               OLD_PID=$(cat ${RUN_DIR}/pid.txt)
               haproxy -D -f ${RUN_DIR}/haproxy.conf -f ${RUN_DIR}/servers.conf -st $OLD_PID

--- a/common/src/main/resources/common/common.bom
+++ b/common/src/main/resources/common/common.bom
@@ -140,7 +140,7 @@ brooklyn.catalog:
             HAPROXY_BIND_OPTIONS: $brooklyn:config("haproxy.bind.options")
 
           install.command: |
-            sudo yum install -y gcc make openssl-devel wget
+            sudo yum install -y gcc make openssl-devel wget util-linux
             haproxy_major_minor=$(echo ${HAPROXY_VERSION} | cut -d. -f1,2)
             wget "http://www.haproxy.org/download/${haproxy_major_minor}/src/haproxy-${HAPROXY_VERSION}.tar.gz"
             tar zxf haproxy-${HAPROXY_VERSION}.tar.gz
@@ -172,3 +172,49 @@ brooklyn.catalog:
           launch.command: |
             haproxy -f haproxy.conf -f servers.conf -c &&
               haproxy -D -f haproxy.conf -f servers.conf -sf $(cat ${PID_FILE})
+
+        brooklyn.initializers:
+        - type: org.apache.brooklyn.core.effector.ssh.SshCommandEffector
+          brooklyn.config:
+            name: configureHaproxy
+            description: |
+              Generate HAProxy configuration from endpoint list
+            shell.env:
+              HAPROXY_PROTOCOL: $brooklyn:config("haproxy.protocol")
+              HAPROXY_ENDPOINTS: $brooklyn:attributeWhenReady("haproxy.endpoints")
+            command: |
+              (
+              flock -o 9
+              cat > ${RUN_DIR}/servers.conf <<-EOF
+              backend servers
+              EOF
+              if [ "${HAPROXY_PROTOCOL}" == "http" ]; then
+              cat >> ${RUN_DIR}/servers.conf <<-EOF
+                mode http
+                option httpchk
+              EOF
+              fi
+              cat >> ${RUN_DIR}/servers.conf <<-EOF
+                balance roundrobin
+              EOF
+              for endpoint in $(echo ${HAPROXY_ENDPOINTS} | tr ',' ' ') ; do
+                echo "  server manager$((++n)) ${endpoint} maxconn 32 ssl \
+                  ca-file ${RUN_DIR}/ca.pem crt ${RUN_DIR}/cert.pem" >> ${RUN_DIR}/servers.conf
+              done
+              OLD_PID=$(cat ${RUN_DIR}/pid.txt)
+              haproxy -D -f ${RUN_DIR}/haproxy.conf -f ${RUN_DIR}/servers.conf -st $OLD_PID
+              # wait for the old process to die before leaving the critical section
+              while test -d "/proc/$OLD_PID" 2> /dev/null; do sleep 1; done;
+              flock -u 9
+              ) 9>>/tmp/configureSwarm.lock
+
+        brooklyn.policies:
+        - type: org.apache.brooklyn.policy.InvokeEffectorOnSensorChange
+          brooklyn.config:
+            effector: configureHaproxy
+            sensor: $brooklyn:sensor("haproxy.endpoints")
+        - type: org.apache.brooklyn.policy.InvokeEffectorOnSensorChange
+          brooklyn.config:
+            effector: configureHaproxy
+            sensor: $brooklyn:sensor("service.isUp")
+

--- a/common/src/main/resources/common/common.bom
+++ b/common/src/main/resources/common/common.bom
@@ -176,12 +176,13 @@ brooklyn.catalog:
         brooklyn.initializers:
         - type: org.apache.brooklyn.core.effector.ssh.SshCommandEffector
           brooklyn.config:
-            name: configureHaproxy
+            name: configureEndpoints
             description: |
               Generate HAProxy configuration from endpoint list
             shell.env:
               HAPROXY_PROTOCOL: $brooklyn:config("haproxy.protocol")
               HAPROXY_ENDPOINTS: $brooklyn:attributeWhenReady("haproxy.endpoints")
+              ENTITY_ID: $brooklyn:attributeWhenReady("entity.id")
             command: |
               (
               flock -o 9
@@ -199,25 +200,24 @@ brooklyn.catalog:
               EOF
               for endpoint in $(echo ${HAPROXY_ENDPOINTS} | tr ',' ' ') ; do
                 if [ "${HAPROXY_PROTOCOL}" == "http" ]; then
-                  echo "  server master$((++n)) ${endpoint} check" >> ${RUN_DIR}/servers.conf
+                  echo "  server node$((++n)) ${endpoint} check" >> ${RUN_DIR}/servers.conf
                 else
-                  echo "  server manager$((++n)) ${endpoint} maxconn 32 ssl ca-file ${RUN_DIR}/ca.pem crt ${RUN_DIR}/cert.pem" >> ${RUN_DIR}/servers.conf
+                  echo "  server node$((++n)) ${endpoint} maxconn 32 ssl ca-file ${RUN_DIR}/ca.pem crt ${RUN_DIR}/cert.pem" >> ${RUN_DIR}/servers.conf
                 fi
               done
-              OLD_PID=$(cat ${RUN_DIR}/pid.txt)
-              haproxy -D -f ${RUN_DIR}/haproxy.conf -f ${RUN_DIR}/servers.conf -st $OLD_PID
+              old_pid=$(cat ${RUN_DIR}/pid.txt)
+              haproxy -D -f ${RUN_DIR}/haproxy.conf -f ${RUN_DIR}/servers.conf -st ${old_pid}
               # wait for the old process to die before leaving the critical section
-              while test -d "/proc/$OLD_PID" 2> /dev/null; do sleep 1; done;
+              while test -d "/proc/${old_pid}" 2> /dev/null; do sleep 1; done;
               flock -u 9
-              ) 9>>/tmp/configureSwarm.lock
+              ) 9>>/tmp/configure.${ENTITY_ID}.lock
 
         brooklyn.policies:
         - type: org.apache.brooklyn.policy.InvokeEffectorOnSensorChange
           brooklyn.config:
-            effector: configureHaproxy
+            effector: configureEndpoints
             sensor: $brooklyn:sensor("haproxy.endpoints")
         - type: org.apache.brooklyn.policy.InvokeEffectorOnSensorChange
           brooklyn.config:
-            effector: configureHaproxy
+            effector: configureEndpoints
             sensor: $brooklyn:sensor("service.isUp")
-

--- a/kubernetes/src/main/resources/kubernetes/kubernetes.bom
+++ b/kubernetes/src/main/resources/kubernetes/kubernetes.bom
@@ -256,42 +256,13 @@ brooklyn.catalog:
           brooklyn.config:
             haproxy.port: $brooklyn:parent().config("kubernetes.apiserver.port")
             haproxy.protocol: "http"
-          brooklyn.initializers:
-            - type: org.apache.brooklyn.core.effector.ssh.SshCommandEffector
-              brooklyn.config:
-                name: configureKubernetes
-                description: |
-                  Generate HAProxy configuration from Kubernetes endpoint list
-                shell.env:
-                  KUBERNETES_ENDPOINTS:
-                    $brooklyn:attributeWhenReady("kubernetes.endpoints")
-                command: |
-                  cat > ${RUN_DIR}/servers.conf <<-EOF
-                  backend servers
-                    mode http
-                    option httpchk
-                    balance roundrobin
-                  EOF
-                  for endpoint in $(echo ${KUBERNETES_ENDPOINTS} | tr ',' ' ') ; do
-                    echo "  server master$((++n)) ${endpoint} check" >> ${RUN_DIR}/servers.conf
-                  done
-                  haproxy -D -f ${RUN_DIR}/haproxy.conf -f ${RUN_DIR}/servers.conf -st $(cat ${RUN_DIR}/pid.txt)
-          brooklyn.policies:
-            - type: org.apache.brooklyn.policy.InvokeEffectorOnSensorChange
-              brooklyn.config:
-                effector: configureKubernetes
-                sensor: $brooklyn:sensor("kubernetes.endpoints")
-            - type: org.apache.brooklyn.policy.InvokeEffectorOnSensorChange
-              brooklyn.config:
-                effector: configureKubernetes
-                sensor: $brooklyn:sensor("service.isUp")
           brooklyn.enrichers:
             - type: org.apache.brooklyn.enricher.stock.Propagator
               brooklyn.config:
                 uniqueTag: master-cluster-endpoints-propagator
                 producer: $brooklyn:entity("kubernetes-master-cluster")
-                propagating:
-                  - $brooklyn:sensor("kubernetes.endpoints")
+                sensorMapping:
+                  $brooklyn:sensor("kubernetes.endpoints"): $brooklyn:sensor("haproxy.endpoints")
             - type: org.apache.brooklyn.enricher.stock.Transformer
               brooklyn.config:
                 uniqueTag: master-cluster-endpoint-publisher

--- a/swarm/src/main/resources/swarm/swarm.bom
+++ b/swarm/src/main/resources/swarm/swarm.bom
@@ -233,9 +233,6 @@ brooklyn.catalog:
             resources.preInstall.latch: $brooklyn:entity("ca-server").attributeWhenReady("service.isUp")
             files.preinstall:
               "classpath://io.brooklyn.clocker.common:common/certificate-functions.sh": certificate-functions.sh
-            post.install.command: |
-              # ensure flock is installed
-              sudo yum install -y util-linux
             pre.launch.command: |
               set -e
               source ${INSTALL_DIR}/certificate-functions.sh
@@ -247,44 +244,13 @@ brooklyn.catalog:
 
               curl -X POST --data-binary @${INSTALL_DIR}/csr.pem  ${CA_REQUEST_ROOT_URL}/sign > ${RUN_DIR}/cert.pem
               cat ${RUN_DIR}/key.pem >> ${RUN_DIR}/cert.pem
-          brooklyn.initializers:
-            - type: org.apache.brooklyn.core.effector.ssh.SshCommandEffector
-              brooklyn.config:
-                name: configureSwarm
-                description: |
-                  Generate HAProxy configuration from Swarm endpoint list
-                shell.env:
-                  SWARM_ENDPOINTS:
-                    $brooklyn:attributeWhenReady("swarm.endpoints")
-                command: |                  
-                  (
-                  flock -o 9
-                  cat > ${RUN_DIR}/servers.conf <<-EOF
-                  backend servers
-                    balance roundrobin
-                  EOF
-                  for endpoint in $(echo ${SWARM_ENDPOINTS} | tr ',' ' ') ; do
-                    echo "  server manager$((++n)) ${endpoint} maxconn 32 ssl \
-                      ca-file ${RUN_DIR}/ca.pem crt ${RUN_DIR}/cert.pem" >> ${RUN_DIR}/servers.conf
-                  done
-                  OLD_PID=$(cat ${RUN_DIR}/pid.txt)
-                  haproxy -D -f ${RUN_DIR}/haproxy.conf -f ${RUN_DIR}/servers.conf -st $OLD_PID
-                  # wait for the old process to die before leaving the critical section
-                  while test -d "/proc/$OLD_PID" 2> /dev/null; do sleep 1; done;
-                  flock -u 9
-                  ) 9>>/tmp/configureSwarm.lock
-          brooklyn.policies:
-            - type: org.apache.brooklyn.policy.InvokeEffectorOnSensorChange
-              brooklyn.config:
-                effector: configureSwarm
-                sensor: $brooklyn:sensor("swarm.endpoints")
           brooklyn.enrichers:
             - type: org.apache.brooklyn.enricher.stock.Propagator
               brooklyn.config:
                 uniqueTag: swarm-endpoints-propagator
                 producer: $brooklyn:entity("docker-swarm-managers")
-                propagating:
-                  - $brooklyn:sensor("swarm.endpoints")
+                sensorMapping:
+                  $brooklyn:sensor("swarm.endpoints"): $brooklyn:sensor("haproxy.endpoints")
             - type: org.apache.brooklyn.enricher.stock.Transformer
               brooklyn.config:
                 uniqueTag: cluster-swarm-endpoint-publisher

--- a/swarm/src/main/resources/swarm/swarm.bom
+++ b/swarm/src/main/resources/swarm/swarm.bom
@@ -233,6 +233,9 @@ brooklyn.catalog:
             resources.preInstall.latch: $brooklyn:entity("ca-server").attributeWhenReady("service.isUp")
             files.preinstall:
               "classpath://io.brooklyn.clocker.common:common/certificate-functions.sh": certificate-functions.sh
+            post.install.command: |
+              # ensure flock is installed
+              sudo yum install -y util-linux
             pre.launch.command: |
               set -e
               source ${INSTALL_DIR}/certificate-functions.sh

--- a/swarm/src/main/resources/swarm/swarm.bom
+++ b/swarm/src/main/resources/swarm/swarm.bom
@@ -255,7 +255,7 @@ brooklyn.catalog:
                     $brooklyn:attributeWhenReady("swarm.endpoints")
                 command: |                  
                   (
-                  flock 9
+                  flock -o 9
                   cat > ${RUN_DIR}/servers.conf <<-EOF
                   backend servers
                     balance roundrobin
@@ -264,7 +264,10 @@ brooklyn.catalog:
                     echo "  server manager$((++n)) ${endpoint} maxconn 32 ssl \
                       ca-file ${RUN_DIR}/ca.pem crt ${RUN_DIR}/cert.pem" >> ${RUN_DIR}/servers.conf
                   done
-                  haproxy -D -f ${RUN_DIR}/haproxy.conf -f ${RUN_DIR}/servers.conf -st $(cat ${RUN_DIR}/pid.txt)
+                  OLD_PID=$(cat ${RUN_DIR}/pid.txt)
+                  haproxy -D -f ${RUN_DIR}/haproxy.conf -f ${RUN_DIR}/servers.conf -st $OLD_PID
+                  # wait for the old process to die before leaving the critical section
+                  while test -d "/proc/$OLD_PID" 2> /dev/null; do sleep 1; done;
                   flock -u 9
                   ) 9>>/tmp/configureSwarm.lock
           brooklyn.policies:

--- a/swarm/src/main/resources/swarm/swarm.bom
+++ b/swarm/src/main/resources/swarm/swarm.bom
@@ -254,6 +254,8 @@ brooklyn.catalog:
                   SWARM_ENDPOINTS:
                     $brooklyn:attributeWhenReady("swarm.endpoints")
                 command: |                  
+                  (
+                  flock 9
                   cat > ${RUN_DIR}/servers.conf <<-EOF
                   backend servers
                     balance roundrobin
@@ -263,6 +265,8 @@ brooklyn.catalog:
                       ca-file ${RUN_DIR}/ca.pem crt ${RUN_DIR}/cert.pem" >> ${RUN_DIR}/servers.conf
                   done
                   haproxy -D -f ${RUN_DIR}/haproxy.conf -f ${RUN_DIR}/servers.conf -st $(cat ${RUN_DIR}/pid.txt)
+                  flock -u 9
+                  ) 9>>/tmp/configureSwarm.lock
           brooklyn.policies:
             - type: org.apache.brooklyn.policy.InvokeEffectorOnSensorChange
               brooklyn.config:


### PR DESCRIPTION
 - guard critical section with flock

Fixes https://cloudsoft.jira.com/browse/CCS-106

The `swarm-manager-load-balancer` sometimes returns an empty response.
This is due to the fact that several instances of `haproxy` are running, so the request may be routed to an instance with an invalid config.

There is a race condition in the `configureSwarm` effector that is called to re-configure `haproxy` every time there is a change in the swarm node list.

If the effector is invoked simultaneously, e.g. when starting up two nodes, it may result in duplicate instances, as new `haproxy` instances are started with an option to kill and replace the old process, but as they don't know about each other, they both live on.

(A different problem may happen if two effector invocations enter the critical section in the wrong order, but this is not resolvable within the effector itself.)