### PR TITLE
Use local IPs for inter-node communication

### DIFF
--- a/kubernetes/catalog/kubernetes/kubernetes.bom
+++ b/kubernetes/catalog/kubernetes/kubernetes.bom
@@ -851,7 +851,7 @@ brooklyn.catalog:
             --config=/etc/kubernetes/manifests \
             --cadvisor-port=${CADVISOR_PORT} \
             --node-ip=${HOST_SUBNET_ADDRESS} \
-            --hostname-override=${HOST_ADDRESS} \
+            --hostname-override=${HOST_SUBNET_ADDRESS} \
             --api-servers=${KUBERNETES_URL} \
             --kubeconfig=/etc/kubernetes/kubeconfig \
             --network-plugin-dir=/etc/cni/net.d \


### PR DESCRIPTION
Using public IPs in Amazon requires the shared security group open to external traffic.

Suggest testing this with the shared security group customizer enabled. If working could update the docs not to require it.

I've tested this with the security groups open to external traffic. If not working with the stock security groups could look at ` --api-servers=${KUBERNETES_URL}` as a potential cause.