### PR TITLE
Move brooklyn-dns-etc-hosts-generator include

### DIFF
--- a/kubernetes/catalog/kubernetes/catalog.bom
+++ b/kubernetes/catalog/kubernetes/catalog.bom
@@ -1,6 +1,5 @@
 brooklyn.catalog:
   items:
-    - https://raw.githubusercontent.com/brooklyncentral/brooklyn-dns/master/brooklyn-dns-etc-hosts-generator.bom
     - classpath://io.brooklyn.etcd.brooklyn-etcd:brooklyn-etcd/catalog.bom
     - classpath://io.brooklyn.clocker.common:docker/catalog.bom
     - classpath://io.brooklyn.clocker.common:common/haproxy.bom

--- a/kubernetes/catalog/kubernetes/kubernetes.bom
+++ b/kubernetes/catalog/kubernetes/kubernetes.bom
@@ -6,6 +6,7 @@ brooklyn.catalog:
     license_code: APACHE-2.0
 
   items:
+  - https://raw.githubusercontent.com/brooklyncentral/brooklyn-dns/master/brooklyn-dns-etc-hosts-generator.bom
   - id: kubernetes-cluster-template
     name: "Kubernetes Cluster"
     description: |


### PR DESCRIPTION
The tests fail because `brooklyn-dns-etc-hosts-generator` is only included in the catalog.bom, which isn't sourced by the tests. I've moved this to `kubernetes.bom` where it's used and will be sourced by the tests.