### PR TITLE
Prevent haproxy daemon's holding of flock

### DIFF
--- a/common/catalog/common/haproxy.bom
+++ b/common/catalog/common/haproxy.bom
@@ -110,7 +110,7 @@ brooklyn.catalog:
               ENTITY_ID: $brooklyn:attributeWhenReady("entity.id")
             command: |
               (
-              flock -o 9
+              flock 9
               cat > ${RUN_DIR}/servers.conf <<-EOF
               backend servers
               EOF
@@ -131,10 +131,9 @@ brooklyn.catalog:
                 fi
               done
               old_pid=$(cat ${RUN_DIR}/pid.txt)
-              haproxy -D -f ${RUN_DIR}/haproxy.conf -f ${RUN_DIR}/servers.conf -st ${old_pid}
+              haproxy -D -f ${RUN_DIR}/haproxy.conf -f ${RUN_DIR}/servers.conf -st ${old_pid} 9>/dev/null
               # wait for the old process to die before leaving the critical section
               while test -d /proc/${old_pid} 2> /dev/null; do sleep 1; done
-              flock -u 9
               ) 9>> /tmp/configure.${ENTITY_ID}.lock
 
         brooklyn.policies:


### PR DESCRIPTION
 Currently fd 9 is associated to flock's lock file in critical section.
 `flock -o 9` was used to ensure that the file itself is closed, while
 the lock is still held by the current process.
 The flock man page explicitly suggests to use `-o` when spawning 
 a child process which should not be holding the lock,
 _but this only works correctly when passing a command_.
 Therefore, after obtaining the lock, the subsequent commands 
 will still have fd 9 available to them.
 When haproxy is started with `-D` it will fork a daemon, and the fd
 will be inherited by the child process.
 Finally, the lock is explicitly released with `flock -u 9`.

 Unfortunately, if any error occurs before releasing the lock (e.g.,
 connection drops) the lock will NOT be released, even if the file is
 closed.
 Inspection of held file locks (with `lslocks`) shows that the original
 parent process ID still holds the lock even after the process has
 been terminated.

 The solution is very simple: redirect fd 9 to `/dev/null` for `haproxy`
 so that the lock is not inherited by the child process.
 In this way the explicit lock release is not necessary any more, and it 
 will happen automatically when the current process exits, either 
 normally or on any error.

_(Edited to clarify why -o does not work as expected)._