### PR TITLE
Fix `swarm.port` usage

### DIFF
--- a/common/catalog/common/ca.bom
+++ b/common/catalog/common/ca.bom
@@ -52,7 +52,7 @@ brooklyn.catalog:
           EMAIL_ADDRESS: $brooklyn:config("email.address")
           CHALLENGE_PASSWORD: $brooklyn:config("challenge.password")
           OPTIONAL_COMPANY_NAME: $brooklyn:config("optional.company.name")
-          CA_SERVER_PORT: $brooklyn:attributeWhenReady("ca.server.port")
+          CA_SERVER_PORT: $brooklyn:config("ca.server.port")
           INSTALL_DIR: $brooklyn:attributeWhenReady("install.dir")
           NODE_PATH:
             $brooklyn:formatString:
@@ -197,10 +197,9 @@ brooklyn.catalog:
           brooklyn.config:
             enricher.triggerSensors:
               - host.address
-              - ca.server.port
             enricher.targetSensor: $brooklyn:sensor("main.uri")
             enricher.targetValue:
               $brooklyn:formatString:
                 - "http://%s:%d"
                 - $brooklyn:attributeWhenReady("host.address")
-                - $brooklyn:attributeWhenReady("ca.server.port")
+                - $brooklyn:config("ca.server.port")

--- a/common/catalog/common/ca.bom
+++ b/common/catalog/common/ca.bom
@@ -38,7 +38,7 @@ brooklyn.catalog:
           label: "CA Server Port"
           description: |
             The external port the CA Server web service listens on
-          type: port
+          type: integer
           default: 8080
 
       brooklyn.config:

--- a/common/catalog/docker/docker.bom
+++ b/common/catalog/docker/docker.bom
@@ -192,7 +192,7 @@ brooklyn.catalog:
           label: "Docker Port"
           description: |
             The TCP port for Docker to listen on
-          type: port
+          type: integer
           default: 2376
         - name: docker.bindaddress
           label: "Docker Bind Address"

--- a/common/catalog/docker/docker.bom
+++ b/common/catalog/docker/docker.bom
@@ -236,26 +236,24 @@ brooklyn.catalog:
             enricher.suppressDuplicates: false
             enricher.triggerSensors:
               - $brooklyn:sensor("host.address")
-              - $brooklyn:sensor("docker.port")
             enricher.targetSensor: $brooklyn:sensor("docker.endpoint.public")
             enricher.targetValue:
               $brooklyn:formatString:
                 - "%s:%d"
                 - $brooklyn:attributeWhenReady("host.address")
-                - $brooklyn:attributeWhenReady("docker.port")
+                - $brooklyn:config("docker.port")
         - type: org.apache.brooklyn.enricher.stock.Transformer
           brooklyn.config:
             uniqueTag: docker-endpoint-generator
             enricher.suppressDuplicates: false
             enricher.triggerSensors:
               - $brooklyn:sensor("host.subnet.address")
-              - $brooklyn:sensor("docker.port")
             enricher.targetSensor: $brooklyn:sensor("docker.endpoint")
             enricher.targetValue:
               $brooklyn:formatString:
                 - "%s:%d"
                 - $brooklyn:attributeWhenReady("host.subnet.address")
-                - $brooklyn:attributeWhenReady("docker.port")
+                - $brooklyn:config("docker.port")
         - type: org.apache.brooklyn.enricher.stock.Transformer
           brooklyn.config:
             uniqueTag: docker-url-generator
@@ -271,14 +269,12 @@ brooklyn.catalog:
           brooklyn.config:
             uniqueTag: docker-bind-url-generator
             enricher.suppressDuplicates: false
-            enricher.triggerSensors:
-              - $brooklyn:sensor("docker.port")
             enricher.targetSensor: $brooklyn:sensor("docker.bind.url")
             enricher.targetValue:
               $brooklyn:formatString:
                 - "tcp://%s:%d"
                 - $brooklyn:config("docker.bindaddress")
-                - $brooklyn:attributeWhenReady("docker.port")
+                - $brooklyn:config("docker.port")
 
       brooklyn.config:
         docker.cert.path:

--- a/common/catalog/docker/docker.bom
+++ b/common/catalog/docker/docker.bom
@@ -265,16 +265,6 @@ brooklyn.catalog:
               $brooklyn:formatString:
                 - "tcp://%s"
                 - $brooklyn:attributeWhenReady("docker.endpoint")
-        - type: org.apache.brooklyn.enricher.stock.Transformer
-          brooklyn.config:
-            uniqueTag: docker-bind-url-generator
-            enricher.suppressDuplicates: false
-            enricher.targetSensor: $brooklyn:sensor("docker.bind.url")
-            enricher.targetValue:
-              $brooklyn:formatString:
-                - "tcp://%s:%d"
-                - $brooklyn:config("docker.bindaddress")
-                - $brooklyn:config("docker.port")
 
       brooklyn.config:
         docker.cert.path:
@@ -359,6 +349,14 @@ brooklyn.catalog:
             period: 5m
             command: |
               cat ${DOCKER_CERT_PATH}/csr.pem
+        - type: org.apache.brooklyn.core.sensor.StaticSensor
+          brooklyn.config:
+            name: docker.bind.url
+            static.value:
+              $brooklyn:formatString:
+                - "tcp://%s:%d"
+                - $brooklyn:config("docker.bindaddress")
+                - $brooklyn:config("docker.port")
 
   - id: docker-engine-with-resilience
     name: "Docker Engine with Resilience"

--- a/common/tests/docker/docker.tests.bom
+++ b/common/tests/docker/docker.tests.bom
@@ -311,7 +311,7 @@ brooklyn.catalog:
             $brooklyn:formatString:
             - "%s:%d"
             - $brooklyn:entity("ca-server").attributeWhenReady("host.address")
-            - $brooklyn:entity("ca-server").attributeWhenReady("ca.server.port")
+            - $brooklyn:entity("ca-server").config("ca.server.port")
 
 
       # A client for talking to the engine
@@ -326,7 +326,7 @@ brooklyn.catalog:
             $brooklyn:formatString:
             - "tcp://%s:%s/"
             - $brooklyn:entity("docker-engine-tls").attributeWhenReady("host.address")
-            - $brooklyn:entity("docker-engine-tls").attributeWhenReady("docker.port")
+            - $brooklyn:entity("docker-engine-tls").config("docker.port")
 
       - type: docker-engine-test
         name: Test Docker over TLS

--- a/swarm/catalog/swarm/swarm.bom
+++ b/swarm/catalog/swarm/swarm.bom
@@ -201,7 +201,7 @@ brooklyn.catalog:
           label: "Swarm Port"
           description: |
             The TCP port the Swarm manager listens on
-          type: port
+          type: integer
           default: 3376
         - name: swarm.scaling.cpu.limit
           label: "Swarm Scaling CPU Limit"
@@ -481,7 +481,7 @@ brooklyn.catalog:
           label: "Swarm Port"
           description: |
             The TCP port the Swarm manager listens on
-          type: port
+          type: integer
           default: 3376
         - name: swarm.strategy
           label: "Swarm Strategy"

--- a/swarm/catalog/swarm/swarm.bom
+++ b/swarm/catalog/swarm/swarm.bom
@@ -504,25 +504,23 @@ brooklyn.catalog:
             uniqueTag: swarm-endpoint-publisher
             enricher.triggerSensors:
               - $brooklyn:sensor("host.subnet.address")
-              - $brooklyn:sensor("swarm.port")
             enricher.targetSensor: $brooklyn:sensor("swarm.endpoint")
             enricher.targetValue:
               $brooklyn:formatString:
                 - "%s:%d"
                 - $brooklyn:attributeWhenReady("host.subnet.address")
-                - $brooklyn:attributeWhenReady("swarm.port")
+                - $brooklyn:config("swarm.port")
         - type: org.apache.brooklyn.enricher.stock.Transformer
           brooklyn.config:
             uniqueTag: swarm-public-endpoint-publisher
             enricher.triggerSensors:
               - $brooklyn:sensor("host.address")
-              - $brooklyn:sensor("swarm.port")
             enricher.targetSensor: $brooklyn:sensor("swarm.endpoint.public")
             enricher.targetValue:
               $brooklyn:formatString:
                 - "%s:%d"
                 - $brooklyn:attributeWhenReady("host.address")
-                - $brooklyn:attributeWhenReady("swarm.port")
+                - $brooklyn:config("swarm.port")
         - type: org.apache.brooklyn.enricher.stock.Transformer
           brooklyn.config:
             uniqueTag: swarm-url-publisher
@@ -580,7 +578,7 @@ brooklyn.catalog:
       brooklyn.config:
         shell.env:
           SWARM_DISCOVERY_URL: $brooklyn:config("swarm.discovery.url")
-          SWARM_PORT: $brooklyn:attributeWhenReady("swarm.port")
+          SWARM_PORT: $brooklyn:config("swarm.port")
           SWARM_ENDPOINT: $brooklyn:attributeWhenReady("swarm.endpoint")
           SWARM_URL: $brooklyn:attributeWhenReady("swarm.url")
           SWARM_STRATEGY: $brooklyn:config("swarm.strategy")


### PR DESCRIPTION
- use `type: integer` for the parameter
- usage of `swarm.port` as config, not as a sensor
