### PR TITLE
Lower default usage

### DIFF
--- a/kubernetes/catalog/kubernetes/kubernetes.bom
+++ b/kubernetes/catalog/kubernetes/kubernetes.bom
@@ -445,7 +445,7 @@ brooklyn.catalog:
           label: "Kubernetes Minimum RAM"
           description: |
             Minimum RAM for provisioning Kubernetes nodes
-          default: 8g
+          default: 8000
         - name: kubernetes.sharedsecuritygroup.create
           label: "Create Kubernetes SharedSecurityGroup"
           description: |

--- a/swarm/catalog/swarm/swarm.bom
+++ b/swarm/catalog/swarm/swarm.bom
@@ -412,7 +412,7 @@ brooklyn.catalog:
           label: "Swarm Minimum RAM"
           description: |
             Minimum RAM for provisioning Swarm nodes
-          default: 8g
+          default: 8000
         - name: swarm.sharedsecuritygroup.create
           label: "Create Swarm SharedSecurityGroup"
           description: |


### PR DESCRIPTION
Clusters and swarms are launched with very large machines by default (16gb of RAM each). This appears to be because of [BROOKLYN-398](https://issues.apache.org/jira/browse/BROOKLYN-398). This avoids the problem here.