### PR TITLE
Reduce test resource requirement

### DIFF
--- a/kubernetes/tests/kubernetes/tests.default.bom
+++ b/kubernetes/tests/kubernetes/tests.default.bom
@@ -24,5 +24,7 @@ brooklyn.catalog:
           kubernetes.pod.cidr: 172.16.0.0/16
           kubernetes.apiserver.port: 8080
           kubernetes.sharedsecuritygroup.create: true
+          kubernetes.minRam: 2000
+          kubernetes.minCores: 1
         services:
           - type: kubernetes-cluster-tests

--- a/kubernetes/tests/kubernetes/tests.no-shared-security-group.bom
+++ b/kubernetes/tests/kubernetes/tests.no-shared-security-group.bom
@@ -24,5 +24,7 @@ brooklyn.catalog:
           kubernetes.pod.cidr: 172.16.0.0/16
           kubernetes.apiserver.port: 8080
           kubernetes.sharedsecuritygroup.create: false
+          kubernetes.minRam: 2000
+          kubernetes.minCores: 1
         services:
           - type: kubernetes-cluster-tests

--- a/swarm/tests/swarm/tests_with_shared_group.bom
+++ b/swarm/tests/swarm/tests_with_shared_group.bom
@@ -18,6 +18,8 @@ brooklyn.catalog:
           timeout.initialStartup: 1h
           timeout.runtimeAssertion: 1h
           swarm.sharedsecuritygroup.create: true
+          swarm.minRam: 2000
+          swarm.minCores: 1
 
         services:
           - type: docker-swarm-tests

--- a/swarm/tests/swarm/tests_without_shared_group.bom
+++ b/swarm/tests/swarm/tests_without_shared_group.bom
@@ -18,6 +18,8 @@ brooklyn.catalog:
           timeout.initialStartup: 1h
           timeout.runtimeAssertion: 1h
           swarm.sharedsecuritygroup.create: false
+          swarm.minRam: 2000
+          swarm.minCores: 1
 
         services:
           - type: docker-swarm-tests


### PR DESCRIPTION
Reduce the amount of resource used by clusters and swarms during the running of tests.