### PR TITLE
Change load balancer URI to use host.name for AWS

### DIFF
--- a/kubernetes/catalog/kubernetes/kubernetes.bom
+++ b/kubernetes/catalog/kubernetes/kubernetes.bom
@@ -275,12 +275,12 @@ brooklyn.catalog:
               brooklyn.config:
                 uniqueTag: master-cluster-endpoint-publisher
                 enricher.triggerSensors:
-                  - $brooklyn:sensor("host.address")
+                  - $brooklyn:sensor("host.name")
                 enricher.targetSensor: $brooklyn:sensor("kubernetes.endpoint")
                 enricher.targetValue:
                   $brooklyn:formatString:
                     - "%s:%d"
-                    - $brooklyn:attributeWhenReady("host.address")
+                    - $brooklyn:attributeWhenReady("host.name")
                     - $brooklyn:config("haproxy.port")
             - type: org.apache.brooklyn.enricher.stock.Transformer
               brooklyn.config:


### PR DESCRIPTION
Required because AWS VPCs set the `host.address` sensor to a VPC local IP address. The `host.name` will resolve correctly to the public IP externally and the VPC IP internally, so use this for the reported `kubernetes.url` sensor that is propagated to the application root as `main.uri` for the dashboard UI.