### PR TITLE
Changed capitalisation of licence

### DIFF
--- a/kubernetes/catalog/kubernetes/kubernetes.bom
+++ b/kubernetes/catalog/kubernetes/kubernetes.bom
@@ -3,7 +3,7 @@ brooklyn.catalog:
   publish:
     description: |
       Resources for working with Kubernetes from Apache Brooklyn
-    license_code: APACHE-2.0
+    license_code: Apache-2.0
 
   items:
   - https://raw.githubusercontent.com/brooklyncentral/brooklyn-dns/master/brooklyn-dns-etc-hosts-generator.bom

--- a/swarm/catalog/swarm/swarm.bom
+++ b/swarm/catalog/swarm/swarm.bom
@@ -3,7 +3,7 @@ brooklyn.catalog:
   publish:
     description: |
       Resources for working with Docker Swarm from Apache Brooklyn
-    license_code: APACHE-2.0
+    license_code: Apache-2.0
     overview: README.md
     qa: tests/swarm.tests.bom
 


### PR DESCRIPTION
Changed capitalisation to conform with SPDX list:
https://spdx.org/licenses/