### PR TITLE
Add loginUser to centos7 entity

### DIFF
--- a/common/catalog/common/common.bom
+++ b/common/catalog/common/common.bom
@@ -49,3 +49,4 @@ brooklyn.catalog:
           provisioning.properties:
             osFamily: centos
             osVersionRegex: 7
+            loginUser: centos


### PR DESCRIPTION
This is short term amendment until [JCLOUDS-1165](https://issues.apache.org/jira/browse/JCLOUDS-1165) is addressed. Currently unless `loginUser: centos` is specified in the location of a CentOS image, Jclouds fails to provision the machine.