### PR TITLE
Specify CentOS7 version for Etcd

### DIFF
--- a/swarm/catalog/swarm/swarm.bom
+++ b/swarm/catalog/swarm/swarm.bom
@@ -91,6 +91,9 @@ brooklyn.catalog:
           brooklyn.config:
             cluster.initial.size: $brooklyn:parent().config("etcd.initial.size")
             etcd.cluster.name: "clocker"
+            provisioning.properties:
+              osFamily: centos
+              osVersionRegex: 7
             etcd.node.spec:
               $brooklyn:entitySpec:
                 type: etcd-node


### PR DESCRIPTION
By default Brooklyn will use Ubuntu for an entity, in order for it to always be Centos (as in k8s) this must be specified.

Tested on AWS