### PR TITLE
Stop Firewalld

### DIFF
--- a/kubernetes/catalog/kubernetes/kubernetes.bom
+++ b/kubernetes/catalog/kubernetes/kubernetes.bom
@@ -508,6 +508,11 @@ brooklyn.catalog:
             sudo yum install -y net-tools traceroute telnet bash-completion
           fi
 
+          # Ensure firewalld is not running
+          sudo yum install -y iptables-services
+          sudo systemctl stop firewalld || true
+          sudo systemctl disable firewalld || true
+
         install.command: |
           sudo yum install -y wget
           wget ${KUBECTL_DOWNLOAD_URL}


### PR DESCRIPTION
Some CentOS 7 images have firewalld instead of iptables (Rightscale for example), this allows k8s to work on such images by stopping firewalld.

* Stops firewalld
* Ensures iptables is installed

Tested with minimal locations on AWS, GCE