### PR TITLE
Fix HAProxy configureEndpoints effector

### DIFF
--- a/common/catalog/common/haproxy.bom
+++ b/common/catalog/common/haproxy.bom
@@ -145,3 +145,17 @@ brooklyn.catalog:
           brooklyn.config:
             effector: configureEndpoints
             sensor: $brooklyn:sensor("service.isUp")
+
+        brooklyn.enrichers:
+        # Publish host+port as main.uri
+        - type: org.apache.brooklyn.enricher.stock.Transformer
+          brooklyn.config:
+            uniqueTag: haproxy-endpoint-publisher
+            enricher.triggerSensors:
+              - $brooklyn:sensor("host.name")
+            enricher.targetSensor: $brooklyn:sensor("org.apache.brooklyn.core.entity.Attributes", "main.uri")
+            enricher.targetValue:
+              $brooklyn:formatString:
+                - "http://%s:%d"
+                - $brooklyn:attributeWhenReady("host.name")
+                - $brooklyn:config("haproxy.port")

--- a/common/catalog/common/haproxy.bom
+++ b/common/catalog/common/haproxy.bom
@@ -109,6 +109,8 @@ brooklyn.catalog:
               HAPROXY_ENDPOINTS: $brooklyn:attributeWhenReady("haproxy.endpoints")
               ENTITY_ID: $brooklyn:attributeWhenReady("entity.id")
             command: |
+              set -x
+              command -v haproxy >/dev/null 2>&1 || { echo >&2 "HAProxy is not installed yet. Exiting quietly."; exit 0; }
               (
               flock 9
               cat > ${RUN_DIR}/servers.conf <<-EOF
@@ -131,9 +133,13 @@ brooklyn.catalog:
                 fi
               done
               old_pid=$(cat ${RUN_DIR}/pid.txt)
-              haproxy -D -f ${RUN_DIR}/haproxy.conf -f ${RUN_DIR}/servers.conf -st ${old_pid} 9>/dev/null
-              # wait for the old process to die before leaving the critical section
-              while test -d /proc/${old_pid} 2> /dev/null; do sleep 1; done
+              if [ ! -z $old_pid ]; then
+                haproxy -D -f ${RUN_DIR}/haproxy.conf -f ${RUN_DIR}/servers.conf -st ${old_pid} 9>/dev/null
+                # wait for the old process to die before leaving the critical section
+                while test -d /proc/${old_pid} 2> /dev/null; do echo >&2 "waiting for ${old_pid} to die" ; sleep 1; done
+              else
+                echo >&2 "no previous process to wait for"
+              fi
               ) 9>> /tmp/configure.${ENTITY_ID}.lock
 
         brooklyn.policies:
@@ -156,6 +162,7 @@ brooklyn.catalog:
             enricher.targetSensor: $brooklyn:sensor("org.apache.brooklyn.core.entity.Attributes", "main.uri")
             enricher.targetValue:
               $brooklyn:formatString:
-                - "http://%s:%d"
+                - "%s://%s:%d"
+                - $brooklyn:config("haproxy.protocol")
                 - $brooklyn:attributeWhenReady("host.name")
                 - $brooklyn:config("haproxy.port")


### PR DESCRIPTION
The HAProxy entity configures its targets by executing an effector called `configureEndpoints`. Previously it did not check that HAProxy was actually installed before attempting to restart the process. This lead to an infinite wait for a non-existent process to die.

Here's the problem in action before this fix:
```
+ old_pid=
+ haproxy -D -f /home/users/sam/brooklyn-managed-processes/apps/qcuiip8b3n/entities/VanillaSoftwareProcess_v43tbxnoze/haproxy.conf -f /home/users/sam/brooklyn-managed-processes/apps/qcuiip8b3n/entities/VanillaSoftwareProcess_v43tbxnoze/servers.conf -st
/tmp/brooklyn-20170209-112518374-aLIE-effector_configureEndpoints_ss.sh: line 35: haproxy: command not found
+ test -d /proc/
+ echo 'waiting for  to die'
+ sleep 1
+ test -d /proc/
+ echo 'waiting for  to die'
+ sleep 1
...
```
I've also added a transformer to publish a value for the `main.uri` sensor