### PR TITLE
(maint) fix typo in README.md cpoyright->copyright

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ brooklyn.catalog:
     - classpath://kubernetes/catalog.bom
 ```
 
-## Cpoyright
+## Copyright
 
 The following icon images have been used, and their use here is believed to be
 acceptable under their licensing terms or fair use doctrine. The source URLs


### PR DESCRIPTION
This PR fixes a trivial typo