### PR TITLE
Fixes maven phasing bug introduced in #410

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ obj
 
 .vagrant
 brooklyn-clocker/
+external-resources/
 
 .checkstyle
 

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -25,6 +25,10 @@
                 <filtering>false</filtering>
             </resource>
             <resource>
+                <directory>external-resources</directory>
+                <filtering>false</filtering>
+            </resource>
+            <resource>
                 <directory>tests</directory>
                 <filtering>false</filtering>
                 <targetPath>tests</targetPath>
@@ -45,7 +49,7 @@
                         <configuration>
                             <url>https://github.com/brooklyncentral/brooklyn-dns/releases/download/v${brooklyn-dns.version}</url>
                             <fromFile>brooklyn-dns-etc-hosts-generator.bom</fromFile>
-                            <toFile>${project.build.directory}/classes/kubernetes/brooklyn-dns-etc-hosts-generator.bom</toFile>
+                            <toFile>${project.basedir}/external-resources/kubernetes/brooklyn-dns-etc-hosts-generator.bom</toFile>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
`brooklyn-dns-etc-hosts-generator.bom` was not being packaged correctly