### PR TITLE
Test will now work, even when endpoint can't be reached

### DIFF
--- a/kubernetes/tests/kubernetes/kubernetes.tests.bom
+++ b/kubernetes/tests/kubernetes/kubernetes.tests.bom
@@ -117,16 +117,21 @@ brooklyn.catalog:
             kubectl get deployments | grep workload- | wc -l
           assertOut:
             contains: '0'
-        - type: org.apache.brooklyn.test.framework.TestHttpCall
+        - type: org.apache.brooklyn.test.framework.TestSshCommand
           name: "14. Check Prometheus UI is Reachable"
-          url:
-            $brooklyn:formatString:
-              - "http://%s:%s"
-              - $brooklyn:entity("prometheus").attributeWhenReady("host.address")
-              - $brooklyn:entity("prometheus").attributeWhenReady("kubernetes.service.port")
-          applyAssertionTo: status
-          assert:
-          - equals: 200
+          brooklyn.config:
+            targetId: prometheus     
+            timeout: 1m       
+            shell.env: 
+              URL: 
+               $brooklyn:formatString:
+                - "curl http://localhost:%s"              
+                - $brooklyn:entity("prometheus").attributeWhenReady("kubernetes.service.port")
+            command: |
+              sudo yum install -y curl
+              curl $URL              
+            assertStatus:
+              equals: 0
         - type: org.apache.brooklyn.test.framework.TestSensor
           name: "15. Size of kubernetes master cluster is 3"
           targetId: kubernetes-master-cluster


### PR DESCRIPTION
For some clouds, we will not have access to the high valued ports.