### PR TITLE
Fix DNS and update Kubernetes test id

### DIFF
--- a/kubernetes/tests/kubernetes/kubernetes.tests.bom
+++ b/kubernetes/tests/kubernetes/kubernetes.tests.bom
@@ -1,21 +1,26 @@
 brooklyn.catalog:
   items:
-  - https://raw.githubusercontent.com/brooklyncentral/common-catalog-utils/master/common-tests/src/main/resources/commontests/common.tests.bom
-  - id: kubernetes-cluster-tests
-    version: "2.1.0-SNAPSHOT" # CLOCKER_VERSION
-    itemType: template
-    iconUrl: https://twitter.com/kubernetesio/profile_image?size=original
-    name: Kubernetes Cluster Tests
-    item:
-      services:
-      - type: kubernetes-cluster-template
-        id: k8s-cluster
-      - type: org.apache.brooklyn.test.framework.TestCase
-        name: K8S Smoke Tests
-        brooklyn.config:
-          timeout: 1h
-          targetId: k8s-cluster
-        brooklyn.children:
+    - https://github.com/brooklyncentral/common-catalog-utils/releases/download/v0.1.0/common.tests.bom
+
+    - id: kubernetes-cluster-tests
+      version: "2.1.0-SNAPSHOT" # CLOCKER_VERSION
+      itemType: template
+      iconUrl: https://twitter.com/kubernetesio/profile_image?size=original
+      name: Kubernetes Cluster Tests
+      item:
+        services:
+          - type: kubernetes-cluster-template
+            id: k8s-cluster
+          - type: kubernetes-smoke-tests
+            id: k8s-smoke-tests
+            brooklyn.config:
+              timeout: 1h
+              targetId: k8s-cluster
+
+    - id: kubernetes-smoke-tests
+      type: org.apache.brooklyn.test.framework.TestCase
+      name: K8S Smoke Tests
+      brooklyn.children:
         - type: assert-up-and-running-initial
           name: "01. K8S cluster up and running"
         - type: assert-reachable
@@ -50,7 +55,6 @@ brooklyn.catalog:
             kubectl get pods | grep -i running
           assertOut:
             contains: 'workload-b'
-
         - type: org.apache.brooklyn.test.framework.SimpleShellCommandTest
           name: "07. Test ICMP [A -> B]"
           target: $brooklyn:entity("kubernetes-master")
@@ -120,7 +124,7 @@ brooklyn.catalog:
         - type: org.apache.brooklyn.test.framework.TestSshCommand
           name: "14. Check Prometheus UI is Reachable"
           brooklyn.config:
-            targetId: prometheus     
+            targetId: prometheus
             timeout: 1m
             shell.env:
               K8S_SERVICE_PORT: $brooklyn:entity("prometheus").attributeWhenReady("kubernetes.service.port")

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <url>https://github.com/brooklyncentral/clocker</url>
 
     <properties>
-        <brooklyn-dns.version>0.1.2</brooklyn-dns.version> <!-- BROOKLYN_DNS_VERSION -->
+        <brooklyn-dns.version>0.1.3</brooklyn-dns.version> <!-- BROOKLYN_DNS_VERSION -->
         <brooklyn-etcd.version>2.5.0-SNAPSHOT</brooklyn-etcd.version> <!-- BROOKLYN_ETCD_VERSION -->
         <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
         <gpg.passphrase/>


### PR DESCRIPTION
Use `brooklyn-dns` version 0.1.3 which fixes concurrency issues and rename the root Kubernetes test catalog entity for eventual use with OpenShift deployments