### PR TITLE
Fix Karaf feature to use groupId for identification

### DIFF
--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>feature</artifactId>
+    <artifactId>clocker-feature</artifactId>
     <name>Clocker :: Feature</name>
     <packaging>feature</packaging>
 

--- a/feature/src/main/feature/feature.xml
+++ b/feature/src/main/feature/feature.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<features xmlns="http://karaf.apache.org/xmlns/features/v1.3.0" name="${project.artifactId}-${project.version}">
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.4.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="http://karaf.apache.org/xmlns/features/v1.4.0"
+          name="${project.groupId}-${project.version}">
 
     <repository>mvn:io.brooklyn.etcd/brooklyn-etcd/${brooklyn-etcd.version}/xml/features</repository>
 
@@ -21,6 +24,7 @@
     <feature name="clocker-swarm" version="${project.version}">
         <bundle>mvn:${project.groupId}/clocker-swarm/${project.version}</bundle>
     </feature>
+
     <feature name="clocker-dependencies" version="${project.version}">
         <feature>brooklyn-etcd</feature>
     </feature>


### PR DESCRIPTION
Changes feature name to e.g.`io.brooklyn.clocker-2.1.0-SNAPSHOT`