### PR TITLE
Fix brooklyn dns etc hosts generator on fire

### DIFF
--- a/kubernetes/catalog/kubernetes/kubernetes.bom
+++ b/kubernetes/catalog/kubernetes/kubernetes.bom
@@ -90,6 +90,8 @@ brooklyn.catalog:
         - type: kubernetes-hosts-file-generator
           id: brooklyn-dns-etc-hosts-generator
           name: "brooklyn-dns-etc-hosts-generator"
+          brooklyn.config:
+            enricher.service_state.children_and_members.quorum.running: atLeastOneUnlessEmpty
         - type: ca-server
           id: ca-server
           name: "ca-server"

--- a/kubernetes/tests/kubernetes/tests.default.bom
+++ b/kubernetes/tests/kubernetes/tests.default.bom
@@ -5,7 +5,7 @@ brooklyn.catalog:
   dependsOn:
     - tests/kubernetes.tests.bom
   items:
-    - id: kubernetes-tests
+    - id: kubernetes-tests-default
       name: "Clocker Kubernetes Tests (DEFAULT)"
       description: |
         Tests on Kubernetes

--- a/kubernetes/tests/kubernetes/tests.no-shared-security-group.bom
+++ b/kubernetes/tests/kubernetes/tests.no-shared-security-group.bom
@@ -5,7 +5,7 @@ brooklyn.catalog:
   dependsOn:
     - tests/kubernetes.tests.bom
   items:
-    - id: kubernetes-tests
+    - id: kubernetes-tests-no-shared-security-group
       name: "Clocker Kubernetes Tests (NO SHARED SECURITY GROUP)"
       description: |
         Tests on Kubernetes


### PR DESCRIPTION
Previously, if a k8s worker or master went on-fire, and was being
elegantly replaced by the cluster’s recovery policy, the group
“brooklyn-dns-etc-hosts-generator” would still mark itself as on-fire
because it’s quorum was “all”. That would cause the whole app to mark
itself as on-fire.
