### PR TITLE
Update node setup to the newest version

### DIFF
--- a/common/catalog/common/ca.bom
+++ b/common/catalog/common/ca.bom
@@ -54,7 +54,7 @@ brooklyn.catalog:
           sudo yum install -y openssl
 
           echo "[CLOCKER] Install Node.js webapp prerequisites"
-          curl --silent --location https://rpm.nodesource.com/setup | sudo bash -
+          curl --silent --location https://rpm.nodesource.com/setup_6.x | sudo bash -
           sudo yum install -y install nodejs
           npm config set prefix ${INSTALL_DIR}
           npm install express@4.13


### PR DESCRIPTION
This update the node setup for the CA server.

The deployment fails on all cloud because of the EOL of node 0.12