### PR TITLE
Update tests.no-shared-security-group.bom

### DIFF
--- a/kubernetes/tests/kubernetes/kubernetes.tests.bom
+++ b/kubernetes/tests/kubernetes/kubernetes.tests.bom
@@ -17,9 +17,9 @@ brooklyn.catalog:
           targetId: k8s-cluster
         brooklyn.children:
         - type: assert-up-and-running-initial
-          name: "01. K8S cluster up and running"
+          name: "1. K8S cluster up and running"
         - type: assert-reachable
-          name: "02. K8S UI Reachable"
+          name: "2. K8S UI Reachable"
           brooklyn.config:
             endpointSensor: main.uri
             timeout: 5m

--- a/kubernetes/tests/kubernetes/kubernetes.tests.bom
+++ b/kubernetes/tests/kubernetes/kubernetes.tests.bom
@@ -23,35 +23,81 @@ brooklyn.catalog:
           brooklyn.config:
             endpointSensor: main.uri
             timeout: 5m
+        - type: org.apache.brooklyn.test.framework.TestSensor
+          name: "3. Size of kubernetes master cluster is 3"
+          targetId: kubernetes-master-cluster
+          sensor: group.members.count
+          assert:
+            equals: 3
+        - type: org.apache.brooklyn.test.framework.SimpleShellCommandTest
+          name: "4. Kill a master node"
+          target: $brooklyn:entity("kubernetes-master")
+          command: |
+            nohup sudo bash -c 'sleep 10 && shutdown -h -t0 now' &
+        - type: org.apache.brooklyn.test.framework.TestSensor
+          name: "5. Size of kubernetes master cluster increased to 4"
+          targetId: kubernetes-master-cluster
+          sensor: group.members.count
+          assert:
+            equals: 4
+        - type: org.apache.brooklyn.test.framework.TestSensor
+          name: "6. Size of kubernetes master cluster decreased to 3"
+          targetId: kubernetes-master-cluster
+          sensor: group.members.count
+          assert:
+            equals: 3
+        - type: org.apache.brooklyn.test.framework.TestSensor
+          name: "7. Size of kubernetes worker cluster is 3"
+          targetId: kubernetes-worker-cluster
+          sensor: group.members.count
+          assert:
+            equals: 3
+        - type: org.apache.brooklyn.test.framework.SimpleShellCommandTest
+          name: "8. Kill a worker node"
+          target: $brooklyn:entity("kubernetes-worker")
+          command: |
+            nohup sudo bash -c 'sleep 10 && shutdown -h -t0 now' &
+        - type: org.apache.brooklyn.test.framework.TestSensor
+          name: "9. Size of kubernetes worker cluster increased to 4"
+          targetId: kubernetes-worker-cluster
+          sensor: group.members.count
+          assert:
+            equals: 4
+        - type: org.apache.brooklyn.test.framework.TestSensor
+          name: "10. Size of kubernetes worker cluster decreased to 3"
+          targetId: kubernetes-worker-cluster
+          sensor: group.members.count
+          assert:
+            equals: 3                        
         - type: invoke-effector
-          name: "03. kubectl create deployment [A]"
+          name: "11. kubectl create deployment [A]"
           target: $brooklyn:entity("kubernetes-master")
           effector: kubectl
           params:
             args: 'run workload-a --image=brooklyncentral/centos:7 --replicas=1 --port=22'
         - type: org.apache.brooklyn.test.framework.SimpleShellCommandTest
-          name: "04. kubectl create deployment [B]"
+          name: "12. kubectl create deployment [B]"
           target: $brooklyn:entity("kubernetes-master")
           assertStatus:
             equals: 0
           command: |
             kubectl run workload-b --image=brooklyncentral/centos:7 --replicas=1 --port=22
         - type: org.apache.brooklyn.test.framework.SimpleShellCommandTest
-          name: "05. Assert [A] running"
+          name: "13. Assert [A] running"
           target: $brooklyn:entity("kubernetes-master")
           command: |
             kubectl get pods | grep -i running
           assertOut:
             contains: 'workload-a'
         - type: org.apache.brooklyn.test.framework.SimpleShellCommandTest
-          name: "06. Assert [B] running"
+          name: "14. Assert [B] running"
           target: $brooklyn:entity("kubernetes-master")
           command: |
             kubectl get pods | grep -i running
           assertOut:
             contains: 'workload-b'
         - type: org.apache.brooklyn.test.framework.SimpleShellCommandTest
-          name: "07. Test ICMP [A -> B]"
+          name: "15. Test ICMP [A -> B]"
           target: $brooklyn:entity("kubernetes-master")
           command: |
             POD_A="$(kubectl get pods -o wide | grep workload-a | tr -s ' ' | cut -d ' ' -f1)"
@@ -60,7 +106,7 @@ brooklyn.catalog:
           assertOut:
             contains: '1 received'
         - type: org.apache.brooklyn.test.framework.SimpleShellCommandTest
-          name: "08. Test ICMP [B -> A]"
+          name: "16. Test ICMP [B -> A]"
           target: $brooklyn:entity("kubernetes-master")
           command: |
             POD_B="$(kubectl get pods -o wide | grep workload-b | tr -s ' ' | cut -d ' ' -f1)"
@@ -69,7 +115,7 @@ brooklyn.catalog:
           assertOut:
             contains: '1 received'
         - type: org.apache.brooklyn.test.framework.SimpleShellCommandTest
-          name: "09. Install Netcat"
+          name: "17. Install Netcat"
           target: $brooklyn:entity("kubernetes-master")
           command: |
             POD_A="$(kubectl get pods -o wide | grep workload-a | tr -s ' ' | cut -d ' ' -f1)"
@@ -77,7 +123,7 @@ brooklyn.catalog:
             kubectl exec ${POD_A} -- yum install -y nc
             kubectl exec ${POD_B} -- yum install -y nc
         - type: org.apache.brooklyn.test.framework.SimpleShellCommandTest
-          name: "10. Check TCP"
+          name: "18. Check TCP"
           target: $brooklyn:entity("kubernetes-master")
           command: |
             POD_A="$(kubectl get pods -o wide | grep workload-a | tr -s ' ' | cut -d ' ' -f1)"
@@ -90,7 +136,7 @@ brooklyn.catalog:
           assertOut:
             contains: 'connect_from_Aconnect_from_B'
         - type: org.apache.brooklyn.test.framework.SimpleShellCommandTest
-          name: "11. Check UDP"
+          name: "19. Check UDP"
           target: $brooklyn:entity("kubernetes-master")
           command: |
             POD_A="$(kubectl get pods -o wide | grep workload-a | tr -s ' ' | cut -d ' ' -f1)"
@@ -104,20 +150,20 @@ brooklyn.catalog:
           assertOut:
             contains: 'connect_from_Aconnect_from_B'
         - type: org.apache.brooklyn.test.framework.SimpleShellCommandTest
-          name: "12. Kill deployments [A,B]"
+          name: "20. Kill deployments [A,B]"
           target: $brooklyn:entity("kubernetes-master")
           command: |
             kubectl delete deployment workload-a
             kubectl delete deployment workload-b
         - type: org.apache.brooklyn.test.framework.SimpleShellCommandTest
-          name: "13. Assert [A,B] NOT running"
+          name: "21. Assert [A,B] NOT running"
           target: $brooklyn:entity("kubernetes-master")
           command: |
             kubectl get deployments | grep workload- | wc -l
           assertOut:
             contains: '0'
         - type: org.apache.brooklyn.test.framework.TestSshCommand
-          name: "14. Check Prometheus UI is Reachable"
+          name: "22. Check Prometheus UI is Reachable"
           brooklyn.config:
             targetId: prometheus
             timeout: 1m
@@ -130,49 +176,3 @@ brooklyn.catalog:
               curl -I --max-time 60 "http://${HOST_SUBNET_ADDRESS}:${K8S_SERVICE_PORT}"
             assertStatus:
               equals: 0
-        - type: org.apache.brooklyn.test.framework.TestSensor
-          name: "15. Size of kubernetes master cluster is 3"
-          targetId: kubernetes-master-cluster
-          sensor: group.members.count
-          assert:
-            equals: 3
-        - type: org.apache.brooklyn.test.framework.SimpleShellCommandTest
-          name: "16. Kill a master node"
-          target: $brooklyn:entity("kubernetes-master")
-          command: |
-            nohup sudo bash -c 'sleep 10 && shutdown -h -t0 now' &
-        - type: org.apache.brooklyn.test.framework.TestSensor
-          name: "17. Size of kubernetes master cluster increased to 4"
-          targetId: kubernetes-master-cluster
-          sensor: group.members.count
-          assert:
-            equals: 4
-        - type: org.apache.brooklyn.test.framework.TestSensor
-          name: "18. Size of kubernetes master cluster decreased to 3"
-          targetId: kubernetes-master-cluster
-          sensor: group.members.count
-          assert:
-            equals: 3
-        - type: org.apache.brooklyn.test.framework.TestSensor
-          name: "19. Size of kubernetes worker cluster is 3"
-          targetId: kubernetes-worker-cluster
-          sensor: group.members.count
-          assert:
-            equals: 3
-        - type: org.apache.brooklyn.test.framework.SimpleShellCommandTest
-          name: "20. Kill a worker node"
-          target: $brooklyn:entity("kubernetes-worker")
-          command: |
-            nohup sudo bash -c 'sleep 10 && shutdown -h -t0 now' &
-        - type: org.apache.brooklyn.test.framework.TestSensor
-          name: "21. Size of kubernetes worker cluster increased to 4"
-          targetId: kubernetes-worker-cluster
-          sensor: group.members.count
-          assert:
-            equals: 4
-        - type: org.apache.brooklyn.test.framework.TestSensor
-          name: "22. Size of kubernetes worker cluster decreased to 3"
-          targetId: kubernetes-worker-cluster
-          sensor: group.members.count
-          assert:
-            equals: 3

--- a/kubernetes/tests/kubernetes/tests.default.bom
+++ b/kubernetes/tests/kubernetes/tests.default.bom
@@ -26,6 +26,6 @@ brooklyn.catalog:
           kubernetes.sharedsecuritygroup.create: true
           kubernetes.minRam: 2000
           kubernetes.minCores: 1
-          autoscaler.resizeUpStabilizationDelay: 300s
+          autoscaler.resizeUpStabilizationDelay: 60s
         services:
           - type: kubernetes-cluster-tests

--- a/kubernetes/tests/kubernetes/tests.default.bom
+++ b/kubernetes/tests/kubernetes/tests.default.bom
@@ -26,5 +26,6 @@ brooklyn.catalog:
           kubernetes.sharedsecuritygroup.create: true
           kubernetes.minRam: 2000
           kubernetes.minCores: 1
+          autoscaler.resizeUpStabilizationDelay: 300s
         services:
           - type: kubernetes-cluster-tests

--- a/kubernetes/tests/kubernetes/tests.no-shared-security-group.bom
+++ b/kubernetes/tests/kubernetes/tests.no-shared-security-group.bom
@@ -26,5 +26,6 @@ brooklyn.catalog:
           kubernetes.sharedsecuritygroup.create: false
           kubernetes.minRam: 2000
           kubernetes.minCores: 1
+          autoscaler.resizeUpStabilizationDelay: 300s
         services:
           - type: kubernetes-cluster-tests

--- a/kubernetes/tests/kubernetes/tests.no-shared-security-group.bom
+++ b/kubernetes/tests/kubernetes/tests.no-shared-security-group.bom
@@ -26,6 +26,6 @@ brooklyn.catalog:
           kubernetes.sharedsecuritygroup.create: false
           kubernetes.minRam: 2000
           kubernetes.minCores: 1
-          autoscaler.resizeUpStabilizationDelay: 300s
+          autoscaler.resizeUpStabilizationDelay: 60s
         services:
           - type: kubernetes-cluster-tests


### PR DESCRIPTION
K8s tests sometimes fail due to the deployment tests causing a resize. After the deployment tests the resize tests would assume a particular cluster size, but it would be wrong.

Increase autoscaler.resizeUpStabilizationDelay from the default of 30s to 60s.

re-arranged k8s tests so the resizing tests happen before deployment tests.