### PR TITLE
Update config keys' deprecated names

### DIFF
--- a/common/catalog/docker/docker.bom
+++ b/common/catalog/docker/docker.bom
@@ -291,7 +291,7 @@ brooklyn.catalog:
           DOCKER_HOST: $brooklyn:attributeWhenReady("docker.url")
           DOCKER_TLS_VERIFY: true
           DOCKER_CERT_PATH: $brooklyn:config("docker.cert.path")
-        resources.preInstall.latch: $brooklyn:entity("ca-server").attributeWhenReady("service.isUp")
+        latch.preInstall.resources: $brooklyn:entity("ca-server").attributeWhenReady("service.isUp")
         files.preinstall:
           "classpath://io.brooklyn.clocker.common:common/certificate-functions.sh": certificate-functions.sh
         customize.command: |

--- a/common/tests/docker/docker.tests.bom
+++ b/common/tests/docker/docker.tests.bom
@@ -306,7 +306,7 @@ brooklyn.catalog:
         name: Docker Engine with TLS
         id: docker-engine-tls
         brooklyn.config:
-          customize.latch: $brooklyn:entity("ca-server").attributeWhenReady("service.isUp")
+          latch.customize: $brooklyn:entity("ca-server").attributeWhenReady("service.isUp")
           ca.request.root.url:
             $brooklyn:formatString:
             - "%s:%d"
@@ -319,7 +319,7 @@ brooklyn.catalog:
         name: Docker client with TLS
         id: tls-client
         brooklyn.config:
-          customize.latch: $brooklyn:entity("ca-server").attributeWhenReady("service.isUp")
+          latch.customize: $brooklyn:entity("ca-server").attributeWhenReady("service.isUp")
           client.address: $brooklyn:attributeWhenReady("host.address")
           ca.url: $brooklyn:entity("ca-server").attributeWhenReady("main.uri")
           docker.url:

--- a/kubernetes/catalog/kubernetes/kubernetes.bom
+++ b/kubernetes/catalog/kubernetes/kubernetes.bom
@@ -113,8 +113,8 @@ brooklyn.catalog:
           brooklyn.config:
             ca.cert: $brooklyn:entity("ca-server").attributeWhenReady("ca.cert")
             ca.request.root.url: $brooklyn:entity("ca-server").attributeWhenReady("main.uri")
-            resources.preInstall.latch: $brooklyn:entity("ca-server").attributeWhenReady("service.isUp")
-            launch.latch: $brooklyn:entity("etcd-cluster").attributeWhenReady("service.isUp")
+            latch.preInstall.resources: $brooklyn:entity("ca-server").attributeWhenReady("service.isUp")
+            latch.launch: $brooklyn:entity("etcd-cluster").attributeWhenReady("service.isUp")
 
   - id: kubernetes-hosts-file-generator
     name: "Kubernetes Hosts File Generator"
@@ -326,15 +326,15 @@ brooklyn.catalog:
                 id: kubernetes-master
                 name: "kubernetes-master"
                 brooklyn.config:
-                  install.latch: $brooklyn:entity("kubernetes-manager-load-balancer").attributeWhenReady("service.isUp")
-                  launch.latch: $brooklyn:entity("etcd-cluster").attributeWhenReady("service.isUp")
+                  latch.install: $brooklyn:entity("kubernetes-manager-load-balancer").attributeWhenReady("service.isUp")
+                  latch.launch: $brooklyn:entity("etcd-cluster").attributeWhenReady("service.isUp")
                   kubernetes.schedulable: false
                 brooklyn.children:
                   - type: child-software-process
                     id: add-calico-pool
                     name: "add-calico-pool"
                     brooklyn.config:
-                      start.latch: $brooklyn:sibling("calico-cni-plugin").attributeWhenReady("service.isUp")
+                      latch.start: $brooklyn:sibling("calico-cni-plugin").attributeWhenReady("service.isUp")
                       shell.env:
                         ETCD_ENDPOINTS: $brooklyn:entity("etcd-cluster").attributeWhenReady("etcd.urls")
                         FLANNEL_NETWORK: $brooklyn:sibling("flannel-network-agent").config("flannel.network")
@@ -346,7 +346,7 @@ brooklyn.catalog:
                     id: kubernetes-pods
                     name: "kubernetes-pods"
                     brooklyn.config:
-                      start.latch: $brooklyn:entity("kubernetes-pods").sibling("kube-apiserver").attributeWhenReady("service.isUp")
+                      latch.start: $brooklyn:entity("kubernetes-pods").sibling("kube-apiserver").attributeWhenReady("service.isUp")
                     brooklyn.children:
                       - type: calico-policy-controller-pod
                         id: calico-policy-controller
@@ -366,8 +366,8 @@ brooklyn.catalog:
                 id: kubernetes-master
                 name: "kubernetes-master"
                 brooklyn.config:
-                  install.latch: $brooklyn:entity("kubernetes-manager-load-balancer").attributeWhenReady("service.isUp")
-                  launch.latch: $brooklyn:entity("etcd-cluster").attributeWhenReady("service.isUp")
+                  latch.install: $brooklyn:entity("kubernetes-manager-load-balancer").attributeWhenReady("service.isUp")
+                  latch.launch: $brooklyn:entity("etcd-cluster").attributeWhenReady("service.isUp")
                   kubernetes.schedulable: false
 
         - type: cluster
@@ -412,7 +412,7 @@ brooklyn.catalog:
                 id: kubernetes-worker
                 name: "kubernetes-worker"
                 brooklyn.config:
-                  launch.latch: $brooklyn:entity("kubernetes-master-cluster").attributeWhenReady("service.isUp")
+                  latch.launch: $brooklyn:entity("kubernetes-master-cluster").attributeWhenReady("service.isUp")
 
   - id: kubernetes-worker
     name: "Kubernetes Worker"
@@ -555,7 +555,7 @@ brooklyn.catalog:
           id: docker-engine
           name: "docker-engine"
           brooklyn.config:
-            start.latch: $brooklyn:sibling("flannel-network-agent").attributeWhenReady("service.isUp")
+            latch.start: $brooklyn:sibling("flannel-network-agent").attributeWhenReady("service.isUp")
             docker.additionaloptions:
               $brooklyn:formatString:
                 - >-
@@ -572,18 +572,18 @@ brooklyn.catalog:
           id: calico-cni-plugin
           name: "calico-cni-plugin"
           brooklyn.config:
-            start.latch: $brooklyn:sibling("docker-engine").attributeWhenReady("service.isUp")
+            latch.start: $brooklyn:sibling("docker-engine").attributeWhenReady("service.isUp")
             etcd.endpoints: $brooklyn:entity("etcd-cluster").attributeWhenReady("etcd.urls")
         - type: kube-proxy-service
           id: kube-proxy
           name: "kube-proxy"
           brooklyn.config:
-            start.latch: $brooklyn:sibling("calico-cni-plugin").attributeWhenReady("service.isUp")
+            latch.start: $brooklyn:sibling("calico-cni-plugin").attributeWhenReady("service.isUp")
         - type: kubelet-service
           id: kubelet
           name: "kubelet"
           brooklyn.config:
-            start.latch: $brooklyn:sibling("calico-cni-plugin").attributeWhenReady("service.isUp")
+            latch.start: $brooklyn:sibling("calico-cni-plugin").attributeWhenReady("service.isUp")
 
       brooklyn.enrichers:
         - type: org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic$ComputeServiceIndicatorsFromChildrenAndMembers
@@ -669,17 +669,17 @@ brooklyn.catalog:
           id: kube-apiserver
           name: "kube-apiserver"
           brooklyn.config:
-            start.latch: $brooklyn:sibling("kubelet").attributeWhenReady("service.isUp")
+            latch.start: $brooklyn:sibling("kubelet").attributeWhenReady("service.isUp")
         - type: kube-controller-manager-service
           id: kube-controller-manager
           name: "kube-controller-manager"
           brooklyn.config:
-            start.latch: $brooklyn:sibling("kube-apiserver").attributeWhenReady("service.isUp")
+            latch.start: $brooklyn:sibling("kube-apiserver").attributeWhenReady("service.isUp")
         - type: kube-scheduler-service
           id: kube-scheduler
           name: "kube-scheduler"
           brooklyn.config:
-            start.latch: $brooklyn:sibling("kube-apiserver").attributeWhenReady("service.isUp")
+            latch.start: $brooklyn:sibling("kube-apiserver").attributeWhenReady("service.isUp")
 
       brooklyn.enrichers:
         - type: org.apache.brooklyn.enricher.stock.Transformer

--- a/swarm/catalog/swarm/swarm.bom
+++ b/swarm/catalog/swarm/swarm.bom
@@ -100,7 +100,7 @@ brooklyn.catalog:
                 name: "etcd-node"
                 brooklyn.config:
                   ca.request.root.url: $brooklyn:entity("ca-server").attributeWhenReady("main.uri")
-                  resources.preInstall.latch: $brooklyn:entity("ca-server").attributeWhenReady("service.isUp")
+                  latch.preInstall.resources: $brooklyn:entity("ca-server").attributeWhenReady("service.isUp")
                   files.preinstall:
                     "classpath://io.brooklyn.clocker.common:common/certificate-functions.sh": certificate-functions.sh
                   shell.env:
@@ -153,8 +153,8 @@ brooklyn.catalog:
             docker.discovery.url: $brooklyn:entity("etcd-cluster").attributeWhenReady("etcd.authority")
             ca.cert: $brooklyn:entity("ca-server").attributeWhenReady("ca.cert")
             ca.request.root.url: $brooklyn:entity("ca-server").attributeWhenReady("main.uri")
-            resources.preInstall.latch: $brooklyn:entity("ca-server").attributeWhenReady("service.isUp")
-            launch.latch: $brooklyn:entity("etcd-cluster").attributeWhenReady("service.isUp")
+            latch.preInstall.resources: $brooklyn:entity("ca-server").attributeWhenReady("service.isUp")
+            latch.launch: $brooklyn:entity("etcd-cluster").attributeWhenReady("service.isUp")
 
   - id:  docker-swarm-cluster
     name: "Docker Swarm Cluster"
@@ -236,7 +236,7 @@ brooklyn.catalog:
                 - $brooklyn:attributeWhenReady("run.dir")
             shell.env:
               CA_REQUEST_ROOT_URL: $brooklyn:config("ca.request.root.url")
-            resources.preInstall.latch: $brooklyn:entity("ca-server").attributeWhenReady("service.isUp")
+            latch.preInstall.resources: $brooklyn:entity("ca-server").attributeWhenReady("service.isUp")
             files.preinstall:
               "classpath://io.brooklyn.clocker.common:common/certificate-functions.sh": certificate-functions.sh
             pre.launch.command: |
@@ -307,7 +307,7 @@ brooklyn.catalog:
                 id: swarm-manager
                 name: "swarm-manager"
                 brooklyn.config:
-                    provision.latch: $brooklyn:entity("swarm-manager-load-balancer").attributeWhenReady("service.isUp")
+                    latch.provision: $brooklyn:entity("swarm-manager-load-balancer").attributeWhenReady("service.isUp")
 
         - type: cluster
           id: docker-swarm-nodes

--- a/swarm/examples/custom-swarm.yaml
+++ b/swarm/examples/custom-swarm.yaml
@@ -52,6 +52,6 @@ services:
           swarm.max.size: 3
           swarm.discovery.url: $brooklyn:entity("consul-cluster").attributeWhenReady("consul.url")
           docker.discovery.url: $brooklyn:entity("consul-cluster").attributeWhenReady("consul.url")
-          launch.latch: $brooklyn:entity("consul-cluster").attributeWhenReady("service.isUp")
-          customize.latch: $brooklyn:entity("ca-server").attributeWhenReady("service.isUp")
+          latch.launch: $brooklyn:entity("consul-cluster").attributeWhenReady("service.isUp")
+          latch.customize: $brooklyn:entity("ca-server").attributeWhenReady("service.isUp")
           ca.request.root.url: $brooklyn:entity("ca-server").attributeWhenReady("main.uri")

--- a/swarm/tests/swarm/swarm.tests.bom
+++ b/swarm/tests/swarm/swarm.tests.bom
@@ -411,7 +411,7 @@ brooklyn.catalog:
           description: |
             A client for talking to the swarm
           brooklyn.config:
-            customize.latch: $brooklyn:entity("swarm").attributeWhenReady("service.isUp")
+            latch.customize: $brooklyn:entity("swarm").attributeWhenReady("service.isUp")
             client.address: $brooklyn:attributeWhenReady("host.address")
             ca.url: $brooklyn:entity("ca-server").attributeWhenReady("main.uri")
             docker.url: $brooklyn:entity("swarm").attributeWhenReady("swarm.url")
@@ -432,7 +432,7 @@ brooklyn.catalog:
               name: "GROUP-2 Test Swarm client"
               brooklyn.config:
                 targetId: swarm-client
-                start.latch: $brooklyn:entity("swarm-client").attributeWhenReady("service.isUp")
+                latch.start: $brooklyn:entity("swarm-client").attributeWhenReady("service.isUp")
               brooklyn.children:
                 - type: test-swarm-scale-up
                   name: "TEST-03 Test Swarm scale up"


### PR DESCRIPTION
Since Brooklyn 0.12.0 ([this PR](https://github.com/apache/brooklyn-server/pull/819) precisely) some config keys' name have been deprecated generated a warning when installing a blueprint using those. 

This fixes it by using the new names.