### PR TITLE
Separate Template from entity

### DIFF
--- a/swarm/catalog/swarm/swarm.bom
+++ b/swarm/catalog/swarm/swarm.bom
@@ -10,7 +10,7 @@ brooklyn.catalog:
     name: "Docker Swarm with Discovery and CA"
     description: |
       Creates a Swarm of Docker engines, of configurable initial size, using an Etcd cluster for discovery.
-    itemType: template
+    itemType: entity
     iconUrl: classpath://io.brooklyn.clocker.swarm:icons/swarm.png
     item:
       services:


### PR DESCRIPTION
Template not always useful so allows someone to only add entity.

The swarm template currently only deploys an out of date swarm so this makes it easier to remove from the catalog.