### PR TITLE
Add stabilisation delay

### DIFF
--- a/kubernetes/catalog/kubernetes/kubernetes.bom
+++ b/kubernetes/catalog/kubernetes/kubernetes.bom
@@ -186,6 +186,13 @@ brooklyn.catalog:
             will automatically be added. The default is 0.95 or 95%
           type: double
           default: 0.95
+        - name: kubernetes.resizeUpStabilizationDelay
+          label: "Kubernetes Resize Stabilization Delay"
+          description: |
+            The time that the average cluster cpu must be above the threshold before another
+            node will automatically be added.
+          type: double
+          default: 30s
         - name: kubernetes.cluster.name
           label: "Kubernetes Cluster Name"
           type: string
@@ -390,7 +397,8 @@ brooklyn.catalog:
                   $brooklyn:entity("kubernetes-cluster").config("kubernetes.initial.size")
                 autoscaler.maxPoolSize:
                   $brooklyn:entity("kubernetes-cluster").config("kubernetes.max.size")
-                autoscaler.resizeUpStabilizationDelay: 30s
+                autoscaler.resizeUpStabilizationDelay:
+                  $brooklyn:entity("kubernetes-cluster").config("kubernetes.resizeUpStabilizationDelay")
                 autoscaler.resizeDownIterationMax: 0 # Disable scaling down
           brooklyn.enrichers:
             - type: org.apache.brooklyn.enricher.stock.Aggregator

--- a/kubernetes/catalog/kubernetes/kubernetes.bom
+++ b/kubernetes/catalog/kubernetes/kubernetes.bom
@@ -191,7 +191,7 @@ brooklyn.catalog:
           description: |
             The time that the average cluster cpu must be above the threshold before another
             node will automatically be added.
-          type: double
+          type: org.apache.brooklyn.util.time.Duration
           default: 30s
         - name: kubernetes.cluster.name
           label: "Kubernetes Cluster Name"

--- a/kubernetes/tests/kubernetes/tests.default.bom
+++ b/kubernetes/tests/kubernetes/tests.default.bom
@@ -27,5 +27,6 @@ brooklyn.catalog:
           kubernetes.minRam: 2000
           kubernetes.minCores: 1
           autoscaler.resizeUpStabilizationDelay: 60s
+          kubernetes.scaling.cpu.limit: 2.0
         services:
           - type: kubernetes-cluster-tests


### PR DESCRIPTION
Adds a stabilisation delay config parameter.

Increases the stabilisation delay and upper bound cpu for scaling in tests. The tests were sometimes scaling up during initial few tests possibly due to killing a master node.
