### PR TITLE
qa tests: reboot machine, rather than replace

### DIFF
--- a/common/tests/docker/docker.tests.bom
+++ b/common/tests/docker/docker.tests.bom
@@ -40,8 +40,12 @@ brooklyn.catalog:
           name: "TEST-03 start process"
         - type: test-restart-process
           name: "TEST-04 restart process"
-        - type: test-restart-machine
-          name: "TEST-05 restart machine"
+        - type: test-case
+          name: "TEST-05 reboot machine"
+          brooklyn.children:
+            - type: ssh-cmd-restart
+            - type: assert-failed
+            - type: assert-up
         - type: test-reachable
           name: "TEST-06 check service is reachable"
           brooklyn.config:

--- a/common/tests/docker/docker.tests.bom
+++ b/common/tests/docker/docker.tests.bom
@@ -46,6 +46,7 @@ brooklyn.catalog:
             - type: ssh-cmd-restart
             - type: assert-failed
             - type: assert-up
+            - type: assert-running
         - type: test-reachable
           name: "TEST-06 check service is reachable"
           brooklyn.config:

--- a/common/tests/docker/tests.bom
+++ b/common/tests/docker/tests.bom
@@ -20,6 +20,10 @@ brooklyn.catalog:
 
         services:
           - type: docker-engine-tests
+            name: Docker Engine Tests
           - type: docker-engine-tls-tests
+            name: Docker Engine TLS Tests
           - type: docker-preinstall-tests
+            name: Docker Pre-install Tests
           - type: docker-vm-container-tests
+            name: Docker VM Container Tests

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,14 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <!-- Override version for maven-install-plugin because there is a bug in
+                3.0.0-M1 preventing installing of modules with packaging of feature
+                see: https://issues.apache.org/jira/browse/MINSTALL-151 -->
+                <version>2.5.2</version>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Motivated by https://issues.apache.org/jira/browse/BROOKLYN-603, which can cause this test to fail if a cloud-cleaner deletes the keypair in the 10 minutes between the VM being initially created and then the VM replaced by the call to `restart(restartMachine: true)`.

Instead, a better test is that the VM survives reboot. I think that is more useful to the user, rather than replacing the VM entirely.