### PR TITLE
Hold back maven-install-plugin to 2.5.2 MINSTALL-151

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <wagon-maven-plugin.version>1.0</wagon-maven-plugin.version>
+        <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
     </properties>
 
     <modules>
@@ -163,6 +164,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${maven-jar-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>${maven-install-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
[ERROR] Failed to execute goal
org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install (default-install)
on project clocker-features: NoFileAssignedException: The packaging plugin for
this project did not assign a main file to the project but it has attachments.
Change packaging to 'pom'. -> [Help 1]

The maven-install-plugin 3.0.0-M1 doesn't handle modules with no primary
artefacts, but that still has attached artefacts.

https://issues.apache.org/jira/browse/MINSTALL-151

Fixes https://jenkins.cloudsoftdev.net/job/builds/job/brooklyn-central/job/clocker/445/